### PR TITLE
Use a tagged release of adoy/oauth2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": ">=5.3.0",
         "illuminate/support": "5.*",
         "auth0/auth0-php": "~1.0",
-        "adoy/oauth2": "dev-master",
+        "adoy/oauth2": "~1.3",
         "illuminate/contracts": "5.*"
     },
     "autoload": {


### PR DESCRIPTION
There is a tagged release of adoy/oauth2.

Would be nice if this project used that (both more stable and easier to set up).