### PR TITLE
Removed note about unstable dependency from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,6 @@ To install this plugin add the following dependency to your composer.json
 
 and run `composer update`
 
-NOTE: Some plugin dependencies are not tagged, so you have to either change the `minimum-stability` to `dev` or you have to add the dependencies manually.
-
-```js
-"adoy/oauth2": "dev-master",
-"illuminate/contracts": "5.*"
-```
-
 ### 2. Enable it in Laravel
 Add the following in the list of the services providers, located in `app/config/app.php`
 


### PR DESCRIPTION
As #15 got in, the message about having to manually adding the dependency for adoy/oauth2 can be removed from the readme.