### PR TITLE
Middleware contract has been deprecated in 5.1

### DIFF
--- a/src/Auth0/Login/Middleware/Auth0JWTMiddleware.php
+++ b/src/Auth0/Login/Middleware/Auth0JWTMiddleware.php
@@ -2,10 +2,9 @@
 
 
 use Auth0\Login\Contract\Auth0UserRepository;
-use Illuminate\Contracts\Routing\Middleware;
 use Auth0\SDK\Exception\CoreException;
 
-class Auth0JWTMiddleware implements Middleware {
+class Auth0JWTMiddleware {
 
     protected $userRepository;
 


### PR DESCRIPTION
See http://laravel.com/docs/master/upgrade#upgrade-5.1.0

The middleware contract is deprecated in 5.1 and will be removed in 5.2 (due december 2015).