### PR TITLE
Auth0 SDK checks for null values instead of false

### DIFF
--- a/src/Auth0/Login/LaravelSessionStore.php
+++ b/src/Auth0/Login/LaravelSessionStore.php
@@ -18,7 +18,7 @@ class LaravelSessionStore {
         Session::put($key_name, $value);
     }
 
-    public function get($key, $default=false) {
+    public function get($key, $default=null) {
         $key_name = $this->getSessionKeyName($key);
 
         return Session::get($key_name, $default);


### PR DESCRIPTION
The Auth0 SDK checks for null values when determining if a user exists.
https://github.com/auth0/auth0-PHP/blob/2.1.2/src/Auth0.php#L276

If the default value for getting a value out of the session store is set to false
```php
        if ($this->user === null) {
            $this->exchangeCode();
        }
```
will never get executed and the user will not be logged in.