### PR TITLE
Remember user

### DIFF
--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -66,6 +66,21 @@ class Auth0Service {
     public function callOnLogin($auth0User) {
         return call_user_func($this->_onLoginCb, $auth0User);
     }
+    
+    private $rememberUser = false;
+    /**
+     * Use this to either enable or disable the "remember" function for users
+     *
+     * @param null $value
+     * @return bool|null
+     */
+    public function rememberUser($value = null) {
+        if($value !== null){
+            $this->rememberUser = $value;
+        }
+
+        return $this->rememberUser;
+    }
 
     private $apiuser;
     public function decodeJWT($encUser) {

--- a/src/controllers/Auth0Controller.php
+++ b/src/controllers/Auth0Controller.php
@@ -37,7 +37,7 @@ class Auth0Controller extends Controller {
                 // If not, the user will be fine
                 $user = $auth0User;
             }
-            \Auth::login($user);
+            \Auth::login($user, $service->rememberUser());
         }
         return  \Redirect::intended('/');
     }


### PR DESCRIPTION
This adds functionality to enable the "remember me" function in laravel.
As with the `onLogin()` method hook to persist or retrieve the user from the local DB, this can be used with the `Auth0` facade.

```
\Auth0::rememberUser(true);
```