### PR TITLE
Fix for Laravel 5.2

### DIFF
--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -60,7 +60,7 @@ class LoginServiceProvider extends ServiceProvider {
         });
 
         // When Laravel logs out, logout the auth0 SDK trough the service
-        \Event::listen('auth.logout', function() {
+        \Event::listen('Illuminate\Auth\Events\Logout', function() {
             \App::make("auth0")->logout();
         });
 


### PR DESCRIPTION
Now the events have a different name. We are listening to "auth.logout" but now it's named "Illuminate\Auth\Events\Logout"

See https://laravel.com/docs/5.2/upgrade


Please check if we are listening to more events and fix them