### PR TITLE
Allow use of RS256 Protocol

### DIFF
--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -130,6 +130,7 @@ class Auth0Service
         }
 
         $verifier = new JWTVerifier([
+            'suported_algs' => ['HS256', 'RS256'],
             'valid_audiences' => [config('laravel-auth0.client_id'), config('laravel-auth0.api_identifier')],
             'client_secret' => config('laravel-auth0.client_secret'),
             'authorized_iss' => config('laravel-auth0.authorized_issuers'),


### PR DESCRIPTION
Note: This pull request may not be the best location for this

The JWTVerifier class defaults to using HS256 unless it is overriden by config.