### PR TITLE
Fix capitalization in namespace

### DIFF
--- a/src/facade/Auth0.php
+++ b/src/facade/Auth0.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Auth0\Login\facade;
+namespace Auth0\Login\Facade;
 
 class Auth0 extends \Illuminate\Support\Facades\Facade
 {


### PR DESCRIPTION
The change in namespace breaks compatibility with previous versions.