### PR TITLE
Use `sub` instead of `user_id` to identify the Auth0 user

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,6 @@ class MyCustomUserRepository implements Auth0UserRepository {
 
     /* This class is used on api authN to fetch the user based on the jwt.*/
     public function getUserByDecodedJWT($jwt) {
-      /* 
-       * The `sub` claim in the token represents the subject of the token
-       * and it is always the `user_id`
-       */
-      $jwt->user_id = $jwt->sub;
-
       return $this->upsertUser($jwt);
     }
 
@@ -68,13 +62,13 @@ class MyCustomUserRepository implements Auth0UserRepository {
 
     protected function upsertUser($profile) {
 
-      $user = User::where("auth0id", $profile->user_id)->first();
+      $user = User::where("auth0id", $profile->sub)->first();
 
       if ($user === null) {
           // If not, create one
           $user = new User();
           $user->email = $profile->email; // you should ask for the email scope
-          $user->auth0id = $profile->user_id;
+          $user->auth0id = $profile->sub;
           $user->name = $profile->name; // you should ask for the name scope
           $user->save();
       }

--- a/src/Auth0/Login/Auth0User.php
+++ b/src/Auth0/Login/Auth0User.php
@@ -30,7 +30,7 @@ class Auth0User implements \Illuminate\Contracts\Auth\Authenticatable
      */
     public function getAuthIdentifier()
     {
-        return $this->userInfo['user_id'];
+        return $this->userInfo['sub'];
     }
 
     /**


### PR DESCRIPTION
Reapleces the usage of `user_id` to identify the auth0 user with the standard claim `sub`