### PR TITLE
Fixed Spelling mistake in config.php

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -88,6 +88,6 @@ return array(
     |   Algs supported by your API
     |
     */
-    // 'suported_algs'        => ['HS256'],
+    // 'supported_algs'        => ['HS256'],
 
 );


### PR DESCRIPTION
Corrected spelling mistake with key 'suported_algs', changed from "suported" to "supported". This also resolves an issue where the alg is defaulted to HS256 because JWTValidator.php cannot see the config value as set.