### PR TITLE
Fix typo in configuration file; Fix namespace for Auth0 facade.

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -88,6 +88,6 @@ return array(
     |   Algs supported by your API
     |
     */
-    // 'suported_algs'        => ['HS256'],
+    // 'supported_algs'        => ['HS256'],
 
 );

--- a/src/facade/Auth0.php
+++ b/src/facade/Auth0.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Auth0\Login\facade;
+namespace Auth0\Login\Facade;
 
 class Auth0 extends \Illuminate\Support\Facades\Facade
 {


### PR DESCRIPTION
This PR fixes the "suported_algs" typo in the config file for the 5.x.x branch. This seems to be fixed in the 4.x.x branch.

This PR also fixes the lowercase "facade" in the Auth0 namespace (should be Facade - capital F).