### PR TITLE
Added guzzle options to config to allow for connection options

### DIFF
--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -148,6 +148,7 @@ class Auth0Service
             'authorized_iss' => config('laravel-auth0.authorized_issuers'),
             'secret_base64_encoded' => $secret_base64_encoded,
             'cache' => $cache,
+            'guzzle_options' => config('laravel-auth0.guzzle_options'),
         ]);
 
         $this->apiuser = $verifier->verifyAndDecode($encUser);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -90,4 +90,13 @@ return array(
     */
     // 'supported_algs'        => ['HS256'],
 
+    /*
+    |--------------------------------------------------------------------------
+    |   Guzzle Options
+    |--------------------------------------------------------------------------
+    |   guzzle_options    (array) optional. Used to specify additional connection options e.g. proxy settings
+    |
+    */
+    //guzzle_options => []
+
 );


### PR DESCRIPTION
For those unfortunate enough to be behind a proxy, verifying tokens fails as the client domain address cannot be reached (e.g. client-domain-name.eu.auth0.com)

Adding connection options to the config allows users of this repo to specify additional options on the guzzle plugin and therefore allow traffic to pass through the proxy and JWT tokens to be verified.

An example configuration:
`     
'guzzle_options' => [ 'curl' => [CURLOPT_PROXY => 'your-proxy-address.com',
                                      CURLOPT_SSL_VERIFYPEER => true,
                                      CURLOPT_PROXYPORT => '8080',
                                      CURLOPT_PROXYUSERPWD => 'username:password']],
`

Thanks