### PR TITLE
Fix php docblock param namespace

### DIFF
--- a/src/Auth0/Login/Contract/Auth0UserRepository.php
+++ b/src/Auth0/Login/Contract/Auth0UserRepository.php
@@ -5,7 +5,7 @@ namespace Auth0\Login\Contract;
 interface Auth0UserRepository
 {
     /**
-     * @param stdClass $jwt with the data provided in the JWT
+     * @param \stdClass $jwt with the data provided in the JWT
      *
      * @return \Illuminate\Contracts\Auth\Authenticatable
      */


### PR DESCRIPTION
I get annoying IDE errors implementing the contract if this isn't fixed.