### PR TITLE
Added the Auth0Service as a singleton through the classname

### DIFF
--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -50,8 +50,11 @@ class LoginServiceProvider extends ServiceProvider {
     public function register()
     {
         // Bind the auth0 name to a singleton instance of the Auth0 Service
+        $this->app->singleton(Auth0Service::class, function () {
+              return new Auth0Service();
+        });
         $this->app->singleton('auth0', function () {
-          return new Auth0Service();
+              return $this->app->make(Auth0Service::class);
         });
 
         // When Laravel logs out, logout the auth0 SDK trough the service


### PR DESCRIPTION
Since the Auth0Service is registered under the name auth0 in the app container it doesn't load the instance when you use it in a constructor, since it is used in the authentication provider like this:

```php
<?php

// ...

/**
 * Service that provides an Auth0\LaravelAuth0\Auth0User stored in the session. This User provider
 * should be used when you don't want to persist the entity.
 */
class Auth0UserProvider implements UserProvider
{
    protected $userRepository;
    protected $auth0;

    /**
     * Auth0UserProvider constructor.
     *
     * @param Auth0UserRepository       $userRepository
     * @param \Auth0\Login\Auth0Service $auth0
     */
    public function __construct(Auth0UserRepository $userRepository, Auth0Service $auth0)
    {
        $this->userRepository = $userRepository;
        $this->auth0 = $auth0;
    }

    // ...

}
```

#Hacktoberfest

Closes #103 