### PR TITLE
Removed laravel prefix from published config file

### DIFF
--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -21,7 +21,7 @@ class Auth0Service
     private $rememberUser = false;
 
     public function __construct() {
-      $this->auth0Config = config('laravel-auth0');
+      $this->auth0Config = config('auth0');
 
       $this->auth0Config['store'] = new LaravelSessionStore();
 
@@ -135,20 +135,20 @@ class Auth0Service
             $cache = null;
         }
 
-        $secret_base64_encoded = config('laravel-auth0.secret_base64_encoded');
+        $secret_base64_encoded = config('auth0.secret_base64_encoded');
 
         if (is_null($secret_base64_encoded)) {
           $secret_base64_encoded = true;
         }
 
         $verifier = new JWTVerifier([
-            'valid_audiences' => [config('laravel-auth0.client_id'), config('laravel-auth0.api_identifier')],
-            'supported_algs' => config('laravel-auth0.supported_algs', ['HS256']),
-            'client_secret' => config('laravel-auth0.client_secret'),
-            'authorized_iss' => config('laravel-auth0.authorized_issuers'),
+            'valid_audiences' => [config('auth0.client_id'), config('auth0.api_identifier')],
+            'supported_algs' => config('auth0.supported_algs', ['HS256']),
+            'client_secret' => config('auth0.client_secret'),
+            'authorized_iss' => config('auth0.authorized_issuers'),
             'secret_base64_encoded' => $secret_base64_encoded,
             'cache' => $cache,
-            'guzzle_options' => config('laravel-auth0.guzzle_options'),
+            'guzzle_options' => config('auth0.guzzle_options'),
         ]);
 
         $this->apiuser = $verifier->verifyAndDecode($encUser);

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -27,7 +27,7 @@ class LoginServiceProvider extends ServiceProvider {
         });
 
         $this->publishes([
-            __DIR__.'/../../config/config.php' => config_path('laravel-auth0.php'),
+            __DIR__.'/../../config/config.php' => config_path('auth0.php'),
         ]);
 
         $laravel = app();


### PR DESCRIPTION
Fixes #101 

Do you like this @joshcanhelp? This more better follows Laravel conventions around packages that publish and load config files to match the config file name `auth0` to the package name of `auth0`.