### PR TITLE
change the visibility of the getter method from private to public

### DIFF
--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -35,7 +35,7 @@ class Auth0Service
      * the config set in the laravel way and using a LaravelSession
      * as a store mechanism.
      */
-    public function getSDK()
+    private function getSDK()
     {
         return $this->auth0;
     }
@@ -164,6 +164,11 @@ class Auth0Service
     public function getAccessToken()
     {
         return $this->getSDK()->getAccessToken();
+    }
+
+    public function getRefreshToken()
+    {
+        return $this->getSDK()->getRefreshToken();
     }
 
     public function jwtuser()

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -35,7 +35,7 @@ class Auth0Service
      * the config set in the laravel way and using a LaravelSession
      * as a store mechanism.
      */
-    private function getSDK()
+    public function getSDK()
     {
         return $this->auth0;
     }


### PR DESCRIPTION
### Changes

I have changed the visibility of the getter method from private to public. I think this makes a sense because the $auth0 variable is private and its getter is private so there is no ability to get auth0 SDK using Auth0Service. In my case, I need access to the getRefreshToken() method of the SDK because this method was not realized in the service but I need to use the same instance of the SDK which used in methods getUser(), getIdToken().
