### PR TITLE
Return null instead of false in Auth0UserProvider.

### DIFF
--- a/src/Auth0/Login/Auth0UserProvider.php
+++ b/src/Auth0/Login/Auth0UserProvider.php
@@ -50,7 +50,7 @@ class Auth0UserProvider implements UserProvider
     public function retrieveByCredentials(array $credentials)
     {
         if (!isset($credentials['api_token'])) {
-            return false;
+            return null;
         }
 
         $encUser = $credentials['api_token'];
@@ -71,7 +71,7 @@ class Auth0UserProvider implements UserProvider
      */
     public function retrieveByToken($identifier, $token)
     {
-        return false;
+        return null;
     }
 
     /**
@@ -86,6 +86,6 @@ class Auth0UserProvider implements UserProvider
      */
     public function validateCredentials(Authenticatable $user, array $credentials)
     {
-        return false;
+        return null;
     }
 }


### PR DESCRIPTION
### Changes

Return null instead of false from `validateCredentials`, `retrieveByToken` and `retrieveByCredentials`, in Auth0UserProvider.

### Why

Because of this function in Illuminate\Auth\GuardHelpers:
```
    /**
     * Determine if the current user is authenticated.
     *
     * @return bool
     */
    public function check()
    {
        return ! is_null($this->user());
    }
```

This caused issues for us when we migrated to auth0, as some of our users utilized remember_token in previous login system.   
Which caused Auth0UserProvider `retrieveByToken` to be called, and returned `false` user, which laravel counts as a "logged in user". 
Which then caused exception when code asked for $user->stuff on a boolean.

In our case, only `retrieveByToken` was called, but it makes sense to me that `retrieveByCredentials` and `validateCredentials` also should return null instead of false.