### PR TITLE
Use LaravelSessionStore in the SessionStateHandler.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "5.* | ^6.0",
-        "auth0/auth0-php": "^5.1.0",
+        "auth0/auth0-php": "^5.6.0",
         "illuminate/contracts": "5.* | ^6.0"
     },
     "autoload": {

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -8,6 +8,7 @@ use Auth0\SDK\Helpers\Cache\CacheHandler;
 use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\Store\StoreInterface;
 use Config;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\BindingResolutionException;
 
 /**
@@ -19,7 +20,7 @@ class Auth0Service
      * @var Auth0
      */
     private $auth0;
-    
+
     private $apiuser;
     private $_onLoginCb = null;
     private $rememberUser = false;
@@ -33,14 +34,25 @@ class Auth0Service
      * @throws \Auth0\SDK\Exception\CoreException
      */
     public function __construct(
-        array $auth0Config,
-        StoreInterface $sessionStorage,
-        SessionStateHandler $sessionStateHandler
+        array $auth0Config = null,
+        StoreInterface $sessionStorage = null,
+        SessionStateHandler $sessionStateHandler = null
     )
     {
+        // Backwards compatible fallbacks
+        if (!$auth0Config instanceof Repository && !is_array($auth0Config)) {
+            $auth0Config = config('laravel-auth0');
+        }
+        if (!$sessionStorage instanceof StoreInterface) {
+            $sessionStorage = new LaravelSessionStore();
+        }
+        if (!$sessionStateHandler instanceof SessionStateHandler) {
+            $sessionStateHandler = new SessionStateHandler($sessionStorage);
+        }
+
+
         $auth0Config['store'] = $sessionStorage;
         $auth0Config['state_handler'] = $sessionStateHandler;
-
         $this->auth0 = new Auth0($auth0Config);
     }
 

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -10,6 +10,7 @@ use Auth0\SDK\Store\StoreInterface;
 use Config;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Http\RedirectResponse;
 
 /**
  * Service that provides access to the Auth0 SDK.
@@ -50,7 +51,6 @@ class Auth0Service
             $sessionStateHandler = new SessionStateHandler($sessionStorage);
         }
 
-
         $auth0Config['store'] = $sessionStorage;
         $auth0Config['state_handler'] = $sessionStateHandler;
         $this->auth0 = new Auth0($auth0Config);
@@ -79,8 +79,17 @@ class Auth0Service
      */
     public function login($connection = null, $state = null, $additional_params = ['scope' => 'openid profile email'], $response_type = 'code')
     {
+        if ($connection && empty( $additional_params['connection'] )) {
+            $additional_params['connection'] = $connection;
+        }
+
+        if ($state && empty( $additional_params['state'] )) {
+            $additional_params['state'] = $state;
+        }
+
         $additional_params['response_type'] = $response_type;
-        $this->auth0->login($state, $connection, $additional_params);
+        $auth_url = $this->auth0->getLoginUrl($additional_params);
+        return new RedirectResponse($auth_url);
     }
 
     /**

--- a/src/Auth0/Login/LaravelSessionStore.php
+++ b/src/Auth0/Login/LaravelSessionStore.php
@@ -21,6 +21,7 @@ class LaravelSessionStore implements StoreInterface
     {
         $key_name = $this->getSessionKeyName($key);
         Session::put($key_name, $value);
+        Session::save();
     }
 
     /**

--- a/src/Auth0/Login/LaravelSessionStore.php
+++ b/src/Auth0/Login/LaravelSessionStore.php
@@ -21,6 +21,10 @@ class LaravelSessionStore implements StoreInterface
     {
         $key_name = $this->getSessionKeyName($key);
         Session::put($key_name, $value);
+
+        // The Auth0 SDK might decide to redirect and exit the PHP execution
+        // before the Laravel middleware can write the changes.
+        // thus we have to persist our changes early
         Session::save();
     }
 

--- a/src/Auth0/Login/LaravelSessionStore.php
+++ b/src/Auth0/Login/LaravelSessionStore.php
@@ -20,12 +20,8 @@ class LaravelSessionStore implements StoreInterface
     public function set($key, $value)
     {
         $key_name = $this->getSessionKeyName($key);
-        Session::put($key_name, $value);
 
-        // The Auth0 SDK might decide to redirect and exit the PHP execution
-        // before the Laravel middleware can write the changes.
-        // thus we have to persist our changes early
-        Session::save();
+        Session::put($key_name, $value);
     }
 
     /**

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -2,11 +2,14 @@
 
 namespace Auth0\Login;
 
-use Illuminate\Support\ServiceProvider;
 use Auth0\SDK\API\Helpers\ApiClient;
 use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\API\Helpers\State\SessionStateHandler;
+use Auth0\SDK\Store\StoreInterface;
+use Illuminate\Support\ServiceProvider;
 
-class LoginServiceProvider extends ServiceProvider {
+class LoginServiceProvider extends ServiceProvider
+{
 
     const SDK_VERSION = "4.0.4";
 
@@ -49,12 +52,24 @@ class LoginServiceProvider extends ServiceProvider {
      */
     public function register()
     {
+        $this->app->bind(StoreInterface::class, function () {
+            return new LaravelSessionStore();
+        });
+
+        $this->app->bind(SessionStateHandler::class, function ($app) {
+            return new SessionStateHandler($app->make(LaravelSessionStore::class));
+        });
+
         // Bind the auth0 name to a singleton instance of the Auth0 Service
-        $this->app->singleton(Auth0Service::class, function () {
-              return new Auth0Service();
+        $this->app->singleton(Auth0Service::class, function ($app) {
+            return new Auth0Service(
+                $app->make('config')->get('laravel-auth0'),
+                $app->make(StoreInterface::class),
+                $app->make(SessionStateHandler::class)
+            );
         });
         $this->app->singleton('auth0', function () {
-              return $this->app->make(Auth0Service::class);
+            return $this->app->make(Auth0Service::class);
         });
 
         // When Laravel logs out, logout the auth0 SDK trough the service


### PR DESCRIPTION
👋 

This is an implementation of the approach I pitched in https://github.com/auth0/laravel-auth0/issues/125 . Let me know what you think 😄

### What has been done
1. Binded the LaravelSesisonStorage and SessionStateHandler to the container. 
  a. I did this so I could re-use it when generating a paswordless `state` token without rebuilding what the SDK already offers for me with the callback handling :)
  b. In addition, by binding it on the `StoreInterface` you could now potentially overwrite the driver for this session storage 🎉 
2. Moved some constructor initialisation logic out of the `Auth0Service`
  a. Since some dependencies are now bound to the app container. Why not pass them as params? :) 
  b. Having less logic in the constructor makes it a bit less error prone and more testable.

### Notes
- Sadly, I changed the constructor method signature of the `Auth0Service` which is public. So these changes are backwards incompatible and require a major version bump. 
- I thought about moving more magic methods out of the class or cleaning it up a bit more. I opted for only changing the stuff that I directly touched. 
- Let me know if you need anything changed, happy to help 😄 


### References

https://github.com/auth0/laravel-auth0/issues/125

### Testing

Can you help me with this? I was unable to find a testing setup. Any way to test this and proof that it works? I did remove some stuff that is unrelated to the issue just because my IDE hinted that it was dead code. 🤔

[x] This change has been tested on the latest version Laravel

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
