### PR TITLE
Replace`setEnvironment` with `setEnvProperty`

### DIFF
--- a/src/Auth0/Login/Auth0JWTUser.php
+++ b/src/Auth0/Login/Auth0JWTUser.php
@@ -41,34 +41,31 @@ class Auth0JWTUser implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Get the password for the user.
-     *
-     * @return string
+     * @return void
      */
     public function getAuthPassword()
     {
-        return;
     }
 
     /**
+     * @return void
      */
     public function getRememberToken()
     {
-        return;
     }
 
     /**
-     * @param $value
+     * @param string $value
      */
     public function setRememberToken($value)
     {
     }
 
     /**
+     * @return void
      */
     public function getRememberTokenName()
     {
-        return;
     }
 
     /**

--- a/src/Auth0/Login/Auth0User.php
+++ b/src/Auth0/Login/Auth0User.php
@@ -57,24 +57,24 @@ class Auth0User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
+     * @return void
      */
     public function getRememberToken()
     {
-        return;
     }
 
     /**
-     * @param $value
+     * @param string $value
      */
     public function setRememberToken($value)
     {
     }
 
     /**
+     * @return void
      */
     public function getRememberTokenName()
     {
-        return;
     }
 
     /**

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -40,7 +40,7 @@ class LoginServiceProvider extends ServiceProvider
         if ($oldInfoHeaders) {
             $infoHeaders = InformationHeaders::Extend($oldInfoHeaders);
 
-            $infoHeaders->setEnvironment('Laravel', $laravel::VERSION);
+            $infoHeaders->setEnvProperty('Laravel', $laravel::VERSION);
             $infoHeaders->setPackage('laravel-auth0', self::SDK_VERSION);
 
             ApiClient::setInfoHeadersData($infoHeaders);

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -14,13 +14,6 @@ class LoginServiceProvider extends ServiceProvider
     const SDK_VERSION = "5.3.0";
 
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
      * Bootstrap the application events.
      */
     public function boot()
@@ -82,15 +75,5 @@ class LoginServiceProvider extends ServiceProvider
         \Event::listen('Illuminate\Auth\Events\Logout', function () {
             \App::make('auth0')->logout();
         });
-    }
-
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return [];
     }
 }


### PR DESCRIPTION
Hey again 👋 

I wondered through the code and saw some small changes. Let me know if you agree. I'd be happy to change anything :)

### Changes

- Replaced `setEnvironment` with `setEnvProperty` since it was marked deprecated in the SDK
- Removed some code from the service provider because I believe it wasn't used. Please challenge me on this if I'm wrong 😄
- Re-aligned some empty return statements for consistency.  

### Testing

Let's check the integration with a running Laravel application. I

- [x] This change has been tested on the latest version Laravel

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
