### PR TITLE
Bind SessionState handler interface in container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@auth0/sdk-team-approvers
+*	@auth0/dx-sdk-approver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@auth0/dx-sdk-approver
+*	@auth0/dx-sdks-approver

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -3,6 +3,7 @@
 namespace Auth0\Login;
 
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
+use Auth0\SDK\API\Helpers\State\StateHandler;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Helpers\Cache\CacheHandler;
 use Auth0\SDK\JWTVerifier;
@@ -31,13 +32,14 @@ class Auth0Service
      *
      * @param array $auth0Config
      * @param StoreInterface $sessionStorage
+     * @param StateHandler|null $stateHandler
      *
      * @throws \Auth0\SDK\Exception\CoreException
      */
     public function __construct(
         array $auth0Config = null,
         StoreInterface $sessionStorage = null,
-        SessionStateHandler $sessionStateHandler = null
+        StateHandler $stateHandler = null
     )
     {
         // Backwards compatible fallbacks
@@ -47,12 +49,12 @@ class Auth0Service
         if (!$sessionStorage instanceof StoreInterface) {
             $sessionStorage = new LaravelSessionStore();
         }
-        if (!$sessionStateHandler instanceof SessionStateHandler) {
-            $sessionStateHandler = new SessionStateHandler($sessionStorage);
+        if (!$stateHandler instanceof StateHandler) {
+            $stateHandler = new SessionStateHandler($sessionStorage);
         }
 
         $auth0Config['store'] = $sessionStorage;
-        $auth0Config['state_handler'] = $sessionStateHandler;
+        $auth0Config['state_handler'] = $stateHandler;
         $this->auth0 = new Auth0($auth0Config);
     }
 

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -2,14 +2,12 @@
 
 namespace Auth0\Login;
 
-use Auth0\SDK\API\Helpers\State\SessionStateHandler;
 use Auth0\SDK\API\Helpers\State\StateHandler;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Helpers\Cache\CacheHandler;
 use Auth0\SDK\JWTVerifier;
 use Auth0\SDK\Store\StoreInterface;
 use Config;
-use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Http\RedirectResponse;
 
@@ -37,22 +35,11 @@ class Auth0Service
      * @throws \Auth0\SDK\Exception\CoreException
      */
     public function __construct(
-        array $auth0Config = null,
-        StoreInterface $sessionStorage = null,
-        StateHandler $stateHandler = null
+        array $auth0Config,
+        StoreInterface $sessionStorage,
+        StateHandler $stateHandler
     )
     {
-        // Backwards compatible fallbacks
-        if (!$auth0Config instanceof Repository && !is_array($auth0Config)) {
-            $auth0Config = config('laravel-auth0');
-        }
-        if (!$sessionStorage instanceof StoreInterface) {
-            $sessionStorage = new LaravelSessionStore();
-        }
-        if (!$stateHandler instanceof StateHandler) {
-            $stateHandler = new SessionStateHandler($sessionStorage);
-        }
-
         $auth0Config['store'] = $sessionStorage;
         $auth0Config['state_handler'] = $stateHandler;
         $this->auth0 = new Auth0($auth0Config);

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -5,6 +5,7 @@ namespace Auth0\Login;
 use Auth0\SDK\API\Helpers\ApiClient;
 use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
+use Auth0\SDK\API\Helpers\State\StateHandler;
 use Auth0\SDK\Store\StoreInterface;
 use Illuminate\Support\ServiceProvider;
 
@@ -49,7 +50,7 @@ class LoginServiceProvider extends ServiceProvider
             return new LaravelSessionStore();
         });
 
-        $this->app->bind(SessionStateHandler::class, function ($app) {
+        $this->app->bind(StateHandler::class, function ($app) {
             return new SessionStateHandler($app->make(LaravelSessionStore::class));
         });
 


### PR DESCRIPTION
Heya,

These are the functional changes extracted from #143 

### Changes

Instead of binding the SessionStateHandler in the container we are now binding the StateHandler interface. This allows for an easier replacement in case someone wants to.

### References

#143 

### Testing

[x] This change has been tested on the latest version Laravel

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
