### PR TITLE
Integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,26 +10,41 @@ commands:
             - composer-v1-{{ checksum "composer.json" }}
             - composer-v1-
       - run: composer install -n --prefer-dist
+      - save_cache:
+          key: composer-v1-{{ checksum "composer.json" }}
+          paths:
+            - vendor
+  test:
+    steps:
+      - run: ./vendor/bin/phpunit
+jobs:
+  php_71:
+    docker:
+      - image: circleci/php:7.1
+    steps:
+      - prepare
+      - test
+  php_72:
+    docker:
+      - image: circleci/php:7.2
+    steps:
+      - prepare
+      - test
+  php_73:
+    docker:
+      - image: circleci/php:7.3
+    steps:
+      - prepare
+      - test
+  snyk:
+    docker:
+      - image: snyk/snyk-cli:composer
+    steps:
       - persist_to_workspace:
           root: .
           paths:
             - composer.*
             - .snyk
-      - save_cache:
-          key: composer-v1-{{ checksum "composer.json" }}
-          paths:
-            - vendor
-
-jobs: 
-  php_7: 
-    docker: 
-      - image: circleci/php:7.1
-    steps:
-      - prepare
-  snyk:
-    docker:
-      - image: snyk/snyk-cli:composer
-    steps:
       - attach_workspace:
           at: .
       - run: snyk test
@@ -45,9 +60,11 @@ jobs:
 workflows:
   snyk:
     jobs:
-      - php_7
+      - php_71
+      - php_72
+      - php_73
       - snyk:
           # Must define SNYK_TOKEN env
-          context: snyk-env 
-          requires: 
-            - php_7
+          context: snyk-env
+          requires:
+            - php_71

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels: []
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
+# Label to use when marking as stale
+staleLabel: closed:stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. If you have not received a response for our team (apologies for the delay) and this is still a blocker, please reply with additional information or just a ping. Thank you for your contribution! 🙇‍♂️

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+build/
 vendor/
 .env
 .DS_Store
 composer.lock
 composer.phar
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -3,14 +3,13 @@
   "description": "Laravel plugin that helps authenticate with the auth0 service",
   "license": "MIT",
   "require": {
-    "php": ">=5.6.4",
-    "illuminate/support": "5.* | ^6.0",
-    "auth0/auth0-php": "^5.6.0",
-    "illuminate/contracts": "5.* | ^6.0"
+    "php": ">=7.1.3",
+    "illuminate/support": "5.5.* | 5.8.* | ^6.0",
+    "illuminate/contracts": "5.5.* | 5.8.* | ^6.0",
+    "auth0/auth0-php": "^5.6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5 | ^8",
-    "orchestra/testbench": "~3.4 | ^4.0"
+    "orchestra/testbench": "3.5.* | 3.8.* | ^4.0"
   },
   "autoload": {
     "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -1,39 +1,39 @@
 {
-    "name": "auth0/login",
-    "description": "Laravel plugin that helps authenticate with the auth0 service",
-    "license": "MIT",
-    "require": {
-        "php": ">=5.6.4",
-        "illuminate/support": "5.* | ^6.0",
-        "auth0/auth0-php": "^5.6.0",
-        "illuminate/contracts": "5.* | ^6.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^5 | ^8",
-        "orchestra/testbench": "~3.4 | ^4.0"
-    },
-    "autoload": {
-        "classmap": [
-            "src/controllers",
-            "src/facade"
-        ],
-        "psr-0": {
-            "Auth0\\Login\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Auth0\\Login\\Tests\\": "tests"
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Auth0\\Login\\LoginServiceProvider"
-            ],
-            "aliases": {
-                "Auth0": "Auth0\\Login\\Facade\\Auth0"
-            }
-        }
+  "name": "auth0/login",
+  "description": "Laravel plugin that helps authenticate with the auth0 service",
+  "license": "MIT",
+  "require": {
+    "php": ">=5.6.4",
+    "illuminate/support": "5.* | ^6.0",
+    "auth0/auth0-php": "^5.6.0",
+    "illuminate/contracts": "5.* | ^6.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^5 | ^8",
+    "orchestra/testbench": "~3.4 | ^4.0"
+  },
+  "autoload": {
+    "classmap": [
+      "src/controllers",
+      "src/facade"
+    ],
+    "psr-0": {
+      "Auth0\\Login\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Auth0\\Login\\Tests\\": "tests"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Auth0\\Login\\LoginServiceProvider"
+      ],
+      "aliases": {
+        "Auth0": "Auth0\\Login\\Facade\\Auth0"
+      }
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,14 @@
     "description": "Laravel plugin that helps authenticate with the auth0 service",
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.4",
         "illuminate/support": "5.* | ^6.0",
         "auth0/auth0-php": "^5.6.0",
         "illuminate/contracts": "5.* | ^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4 | ^7"
+        "phpunit/phpunit": "^5 | ^8",
+        "orchestra/testbench": "~3.4 | ^4.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -1,38 +1,38 @@
 {
-  "name": "auth0/login",
-  "description": "Laravel plugin that helps authenticate with the auth0 service",
-  "license": "MIT",
-  "require": {
-    "php": ">=7.1.3",
-    "illuminate/support": "5.5.* | 5.8.* | ^6.0",
-    "illuminate/contracts": "5.5.* | 5.8.* | ^6.0",
-    "auth0/auth0-php": "^5.6.0"
-  },
-  "require-dev": {
-    "orchestra/testbench": "3.5.* | 3.8.* | ^4.0"
-  },
-  "autoload": {
-    "classmap": [
-      "src/controllers",
-      "src/facade"
-    ],
-    "psr-0": {
-      "Auth0\\Login\\": "src/"
+    "name": "auth0/login",
+    "description": "Laravel plugin that helps authenticate with the auth0 service",
+    "license": "MIT",
+    "require": {
+        "php": ">=7.1.3",
+        "illuminate/support": "5.5.* | 5.8.* | ^6.0",
+        "illuminate/contracts": "5.5.* | 5.8.* | ^6.0",
+        "auth0/auth0-php": "^5.6.0"
+    },
+    "require-dev": {
+        "orchestra/testbench": "3.5.* | 3.8.* | ^4.0"
+    },
+    "autoload": {
+        "classmap": [
+            "src/controllers",
+            "src/facade"
+        ],
+        "psr-0": {
+            "Auth0\\Login\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Auth0\\Login\\Tests\\": "tests"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Auth0\\Login\\LoginServiceProvider"
+            ],
+            "aliases": {
+                "Auth0": "Auth0\\Login\\Facade\\Auth0"
+            }
+        }
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Auth0\\Login\\Tests\\": "tests"
-    }
-  },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "Auth0\\Login\\LoginServiceProvider"
-      ],
-      "aliases": {
-        "Auth0": "Auth0\\Login\\Facade\\Auth0"
-      }
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,13 @@
     "description": "Laravel plugin that helps authenticate with the auth0 service",
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "illuminate/support": "5.* | ^6.0",
         "auth0/auth0-php": "^5.6.0",
         "illuminate/contracts": "5.* | ^6.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4 | ^7"
     },
     "autoload": {
         "classmap": [
@@ -15,6 +18,11 @@
         ],
         "psr-0": {
             "Auth0\\Login\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Auth0\\Login\\Tests\\": "tests"
         }
     },
     "extra": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Auth0 Laravel Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -45,11 +45,13 @@ return [
     |--------------------------------------------------------------------------
     |   persist_user            (Boolean) Optional. Indicates if you want to persist the user info, default true
     |   persist_access_token    (Boolean) Optional. Indicates if you want to persist the access token, default false
+    |   persist_refresh_token   (Boolean) Optional. Indicates if you want to persist the refresh token, default false
     |   persist_id_token        (Boolean) Optional. Indicates if you want to persist the id token, default false
     |
     */
     'persist_user' => true,
     'persist_access_token' => false,
+    'persist_refresh_token' => false,
     'persist_id_token' => false,
 
     /*

--- a/tests/Integration/Facade/Auth0Test.php
+++ b/tests/Integration/Facade/Auth0Test.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Auth0\Login\Tests\Integration\Facade;
+
+use Auth0\Login\Auth0Service;
+use Auth0\Login\Tests\Integration\TestCase;
+
+class Auth0Test extends TestCase
+{
+    public function testFacadeAccessorResolvesToAuth0Service()
+    {
+        $this->assertInstanceOf(Auth0Service::class, $this->app->make('auth0'));
+    }
+}

--- a/tests/Integration/LaravelSessionStoreTest.php
+++ b/tests/Integration/LaravelSessionStoreTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Auth0\Login\Tests\Integration;
+
+use Auth0\Login\LaravelSessionStore;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class LaravelSessionStoreTest extends TestCase
+{
+    /**
+     * @var LaravelSessionStore
+     */
+    private $sessionStorage;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->sessionStorage = new LaravelSessionStore();
+    }
+
+    public function testAutoPrependsAuth0DoubleUnderscore()
+    {
+        $testValue = 'Hello world!';
+
+        $this->sessionStorage->set('testkey', $testValue);
+
+        $this->assertEquals($testValue, $this->app->make('session')->get('auth0__testkey'));
+    }
+
+    /**
+     * Because the LaravelSessionHandler uses the Session Facade, we can easily replace
+     * our storage driver without changing any code.
+     */
+    public function testDifferentSessionStorage()
+    {
+        $testValue = 'Its happening!';
+        $this->app['config']->set('session.driver', 'database');
+        $this->app['config']->set('session.connection', 'sessions');
+        $this->app['config']->set('database.default', 'sessions');
+        $this->app['config']->set('database.connections.sessions', ['driver' => 'sqlite', 'database' => ':memory:']);
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->string('id')->unique();
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->text('payload');
+            $table->integer('last_activity');
+        });
+
+        $this->sessionStorage->set('testkey', $testValue);
+        $this->app->make('session')->save();
+
+        $sessionsInDb = $this->app->make('db')->select('select * from sessions');
+        $this->assertCount(1, $sessionsInDb);
+    }
+}

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Auth0\Login\Tests\Integration;
+
+use Auth0\Login\LoginServiceProvider;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    /**
+     * @inheritDoc
+     *
+     * We setup some application config since some of the constructors
+     * in the Auth0 SDK validate the configuration.
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('laravel-auth0', [
+            'domain' => 'auth0-laravel-testing',
+            'client_id' => 'auth0-laravel-testing-client',
+            'client_secret' => 'auth0-laravel-testing-secret',
+            'redirect_uri' => 'localhost'
+        ]);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [LoginServiceProvider::class];
+    }
+}

--- a/tests/Unit/Auth0JWTUserTest.php
+++ b/tests/Unit/Auth0JWTUserTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Auth0\Login\Tests\Unit;
+
+use Auth0\Login\Auth0JWTUser;
+use PHPUnit\Framework\TestCase;
+
+class Auth0JWTUserTest extends TestCase
+{
+    /**
+     * @var Auth0JWTUser
+     */
+    protected $auth0JwtUser;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->auth0JwtUser = new Auth0JWTUser((object)[
+            "name" => "John Doe",
+            "iss" => "http://auth0.com",
+            "sub" => "someone@example.com",
+            "aud" => "http://example.com",
+            "exp" => 1357000000
+        ]);
+    }
+
+    public function testAuthIdentifierNameIsSubjectOfJWTToken()
+    {
+        $this->assertEquals('someone@example.com', $this->auth0JwtUser->getAuthIdentifierName());
+    }
+
+    public function testAuthIdentifierIsSubjectOfJWTToken()
+    {
+        $this->assertEquals('someone@example.com', $this->auth0JwtUser->getAuthIdentifier());
+    }
+
+    public function testGetAuthPasswordWillNotReturnAnything()
+    {
+        $this->assertEquals('', $this->auth0JwtUser->getAuthPassword());
+    }
+
+    public function testObjectHoldsNoRememberTokenInformation()
+    {
+        $this->auth0JwtUser->setRememberToken('testing123');
+
+        $this->assertEquals('', $this->auth0JwtUser->getRememberToken());
+        $this->assertEquals('', $this->auth0JwtUser->getRememberTokenName());
+    }
+
+    public function testGettersCanReturnTokenClaims()
+    {
+        // Retrieve issuer claim
+        $this->assertEquals('http://auth0.com', $this->auth0JwtUser->iss);
+    }
+}

--- a/tests/Unit/Auth0JWTUserTest.php
+++ b/tests/Unit/Auth0JWTUserTest.php
@@ -12,7 +12,7 @@ class Auth0JWTUserTest extends TestCase
      */
     protected $auth0JwtUser;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
         $this->auth0JwtUser = new Auth0JWTUser((object)[


### PR DESCRIPTION
### Changes

Based upon #149 this PR will re-introduce the BC breaks. To prevent a lot of complexity I would like to pitch the idea of only focussing on the supported Laravel versions in this release. It's quite a big step and we would be removing a lot of PHP versions, so I get that you might challenge this idea 😄 

### References

- The original code is from PR #143 
- The diff is a bit noisy, we could merge #153 first for more clarity

### Testing

[x] This change has been tested on the latest version Laravel

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
