### PR TITLE
Allow store and state_handler to be passed in from config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,18 @@ commands:
           paths:
             - vendor
 
-jobs: 
-  php_7: 
-    docker: 
+jobs:
+  php_7:
+    docker:
       - image: circleci/php:7.1
     steps:
       - prepare
+      - run:
+          name: Check PHP Compatibility
+          command: composer phpcs
+      - run:
+          name: Run Tests
+          command: composer test
   snyk:
     docker:
       - image: snyk/snyk-cli:composer
@@ -48,6 +54,6 @@ workflows:
       - php_7
       - snyk:
           # Must define SNYK_TOKEN env
-          context: snyk-env 
-          requires: 
+          context: snyk-env
+          requires:
             - php_7

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<ruleset name="Laravel-Auth0" namespace="Auth0PHP\CS\Standard">
+    <description>A custom coding standard for the Laravel Auth0 package</description>
+
+    <file>./src</file>
+
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="sp"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="."/>
+
+    <!-- Show coloured output, if available. -->
+    <arg name="colors"/>
+
+    <!--
+    PHPCompatibility sniffs to check for PHP cross-version incompatible code.
+    https://github.com/PHPCompatibility/PHPCompatibility
+    -->
+    <config name="testVersion" value="5.5-"/>
+    <rule ref="PHPCompatibility"/>
+
+</ruleset>

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,15 @@
         "illuminate/contracts": "5.* | ^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4 | ^7"
+        "phpunit/phpunit": "^4 | ^7",
+        "squizlabs/php_codesniffer": "^3.2",
+        "phpcompatibility/php-compatibility": "^8.1",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
+    },
+    "scripts": {
+        "test": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --coverage-text ",
+        "phpcs": "\"vendor/bin/phpcs\"",
+        "sniffs": "\"vendor/bin/phpcs\" -e"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         "phpunit/phpunit": "^4 | ^7",
         "squizlabs/php_codesniffer": "^3.2",
         "phpcompatibility/php-compatibility": "^8.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+        "orchestra/testbench": "^3.8"
     },
     "scripts": {
         "test": "SHELL_INTERACTIVE=1 \"vendor/bin/phpunit\" --coverage-text ",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,11 +19,4 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -45,12 +45,12 @@ class Auth0Service
             $auth0Config = config('laravel-auth0');
         }
 
-        $store = $auth0Config['store'] ?? $store;
+        $store = isset( $auth0Config['store'] ) ? $auth0Config['store'] : $store;
         if (false !== $store && !$store instanceof StoreInterface) {
             $store = new LaravelSessionStore();
         }
 
-        $stateHandler = $auth0Config['state_handler'] ?? $stateHandler;
+        $stateHandler = isset( $auth0Config['state_handler'] ) ? $auth0Config['state_handler'] : $stateHandler;
         if (false !== $stateHandler && !$stateHandler instanceof StateHandler) {
             $stateHandler = new SessionStateHandler($store);
         }

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -2,6 +2,7 @@
 
 namespace Auth0\Login;
 
+use Auth0\SDK\API\Helpers\State\StateHandler;
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
 use Auth0\SDK\Auth0;
 use Auth0\SDK\Helpers\Cache\CacheHandler;
@@ -36,23 +37,26 @@ class Auth0Service
      */
     public function __construct(
         array $auth0Config = null,
-        StoreInterface $sessionStorage = null,
-        SessionStateHandler $sessionStateHandler = null
+        StoreInterface $store = null,
+        StateHandler $stateHandler = null
     )
     {
-        // Backwards compatible fallbacks
         if (!$auth0Config instanceof Repository && !is_array($auth0Config)) {
             $auth0Config = config('laravel-auth0');
         }
-        if (!$sessionStorage instanceof StoreInterface) {
-            $sessionStorage = new LaravelSessionStore();
-        }
-        if (!$sessionStateHandler instanceof SessionStateHandler) {
-            $sessionStateHandler = new SessionStateHandler($sessionStorage);
+
+        $store = $auth0Config['store'] ?? $store;
+        if (false !== $store && !$store instanceof StoreInterface) {
+            $store = new LaravelSessionStore();
         }
 
-        $auth0Config['store'] = $sessionStorage;
-        $auth0Config['state_handler'] = $sessionStateHandler;
+        $stateHandler = $auth0Config['state_handler'] ?? $stateHandler;
+        if (false !== $stateHandler && !$stateHandler instanceof StateHandler) {
+            $stateHandler = new SessionStateHandler($store);
+        }
+
+        $auth0Config['store'] = $store;
+        $auth0Config['state_handler'] = $stateHandler;
         $this->auth0 = new Auth0($auth0Config);
     }
 

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -4,6 +4,7 @@ namespace Auth0\Login;
 
 use Auth0\SDK\API\Helpers\ApiClient;
 use Auth0\SDK\API\Helpers\InformationHeaders;
+use Auth0\SDK\API\Helpers\State\StateHandler;
 use Auth0\SDK\API\Helpers\State\SessionStateHandler;
 use Auth0\SDK\Store\StoreInterface;
 use Illuminate\Support\ServiceProvider;
@@ -49,7 +50,7 @@ class LoginServiceProvider extends ServiceProvider
             return new LaravelSessionStore();
         });
 
-        $this->app->bind(SessionStateHandler::class, function ($app) {
+        $this->app->bind(StateHandler::class, function ($app) {
             return new SessionStateHandler($app->make(LaravelSessionStore::class));
         });
 
@@ -58,7 +59,7 @@ class LoginServiceProvider extends ServiceProvider
             return new Auth0Service(
                 $app->make('config')->get('laravel-auth0'),
                 $app->make(StoreInterface::class),
-                $app->make(SessionStateHandler::class)
+                $app->make(StateHandler::class)
             );
         });
         $this->app->singleton('auth0', function () {

--- a/tests/Auth0ServiceTest.php
+++ b/tests/Auth0ServiceTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace Auth0\Login\Tests;
+
+use Auth0\Login\Auth0Service;
+use Auth0\Login\Facade\Auth0 as Auth0Facade;
+use Auth0\Login\LoginServiceProvider as Auth0ServiceProvider;
+use Auth0\SDK\API\Helpers\State\DummyStateHandler;
+use Auth0\SDK\Store\EmptyStore;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Session;
+
+class Auth0ServiceTest extends OrchestraTestCase
+{
+    public static $defaultConfig;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::$defaultConfig = [
+            'domain' => 'test.auth0.com',
+            'client_id' => '__test_client_id__',
+            'client_secret' => '__test_client_secret__',
+            'redirect_uri' => 'https://example.com/callback',
+        ];
+    }
+
+    public function testThatServiceUsesSessionStoreByDefault()
+    {
+        Session::put('auth0__user', '__test_user__');
+        $service = new Auth0Service(self::$defaultConfig);
+        $user = $service->getUser();
+
+        $this->assertArrayHasKey('profile', $user);
+        $this->assertEquals('__test_user__', $user['profile']);
+    }
+
+    public function testThatServiceSetsEmptyStoreFromConfigAndConstructor()
+    {
+        Session::put('auth0__user', '__test_user__');
+
+        $service = new Auth0Service(self::$defaultConfig + ['store' => false, 'state_handler' => false]);
+        $this->assertNull($service->getUser());
+
+        $service = new Auth0Service(self::$defaultConfig, new EmptyStore(), new DummyStateHandler());
+        $this->assertNull($service->getUser());
+
+        $service = new Auth0Service(self::$defaultConfig);
+        $this->assertIsArray($service->getUser());
+    }
+
+    public function testThatServiceLoginReturnsRedirect()
+    {
+
+        $service = new Auth0Service(self::$defaultConfig);
+        $redirect = $service->login();
+
+        $this->assertInstanceOf( \Illuminate\Http\RedirectResponse::class, $redirect );
+
+        $targetUrl = parse_url($redirect->getTargetUrl());
+
+        $this->assertEquals('test.auth0.com', $targetUrl['host']);
+
+        $targetUrlQuery = explode('&', $targetUrl['query']);
+
+        $this->assertContains('redirect_uri=https%3A%2F%2Fexample.com%2Fcallback', $targetUrlQuery);
+        $this->assertContains('client_id=__test_client_id__', $targetUrlQuery);
+    }
+
+    /*
+     * Test suite helpers
+     */
+
+    protected function getPackageProviders($app)
+    {
+        return [Auth0ServiceProvider::class];
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'Auth0' => Auth0Facade::class,
+        ];
+    }
+}


### PR DESCRIPTION
### Changes

- Fix a bug that did not allow the configuration file values to be used for user store and state handler
- Fix a type hinting bug that did not allow new state handlers to be passed in
- Add a compatibility scan to CI

### References

Closes #154 

### Testing

- [x] This change adds unit tests
- [x] This change has been tested on PHP 7.1 and Laravel 5.8