### PR TITLE
Use array for Auth0JWTUser and add repo return types

### DIFF
--- a/src/Auth0/Login/Auth0JWTUser.php
+++ b/src/Auth0/Login/Auth0JWTUser.php
@@ -15,9 +15,9 @@ class Auth0JWTUser implements \Illuminate\Contracts\Auth\Authenticatable
      *
      * @param $userInfo
      */
-    public function __construct($userInfo)
+    public function __construct(array $userInfo)
     {
-        $this->userInfo = get_object_vars($userInfo);
+        $this->userInfo = $userInfo;
     }
 
     /**

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -162,12 +162,12 @@ class Auth0Service
      * @param $encUser
      * @param array $verifierOptions
      *
-     * @return object
+     * @return array
      * @throws \Auth0\SDK\Exception\InvalidTokenException
      */
     public function decodeJWT($encUser, array $verifierOptions = [])
     {
-        $this->apiuser = (object) $this->auth0->decodeIdToken($encUser, $verifierOptions);
+        $this->apiuser = $this->auth0->decodeIdToken($encUser, $verifierOptions);
         return $this->apiuser;
     }
 

--- a/src/Auth0/Login/Auth0User.php
+++ b/src/Auth0/Login/Auth0User.php
@@ -14,10 +14,10 @@ class Auth0User implements \Illuminate\Contracts\Auth\Authenticatable
     /**
      * Auth0User constructor.
      *
-     * @param $userInfo
+     * @param array $userInfo
      * @param $accessToken
      */
-    public function __construct($userInfo, $accessToken)
+    public function __construct(array $userInfo, $accessToken)
     {
         $this->userInfo = $userInfo;
         $this->accessToken = $accessToken;

--- a/src/Auth0/Login/Contract/Auth0UserRepository.php
+++ b/src/Auth0/Login/Contract/Auth0UserRepository.php
@@ -2,26 +2,28 @@
 
 namespace Auth0\Login\Contract;
 
+use \Illuminate\Contracts\Auth\Authenticatable;
+
 interface Auth0UserRepository
 {
     /**
-     * @param stdClass $jwt with the data provided in the JWT
+     * @param array $decodedJwt with the data provided in the JWT
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @return Authenticatable
      */
-    public function getUserByDecodedJWT($jwt);
+    public function getUserByDecodedJWT(array $decodedJwt) : Authenticatable;
 
     /**
      * @param array $userInfo representing the user profile and user accessToken
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @return Authenticatable
      */
-    public function getUserByUserInfo($userInfo);
+    public function getUserByUserInfo(array $userInfo) : Authenticatable;
 
     /**
-     * @param $identifier the user id
+     * @param string|int|null $identifier the user id
      *
-     * @return \Illuminate\Contracts\Auth\Authenticatable
+     * @return Authenticatable|null
      */
-    public function getUserByIdentifier($identifier);
+    public function getUserByIdentifier($identifier) : ?Authenticatable;
 }

--- a/src/Auth0/Login/Repository/Auth0UserRepository.php
+++ b/src/Auth0/Login/Repository/Auth0UserRepository.php
@@ -5,17 +5,18 @@ namespace Auth0\Login\Repository;
 use Auth0\Login\Auth0User;
 use Auth0\Login\Auth0JWTUser;
 use Auth0\Login\Contract\Auth0UserRepository as Auth0UserRepositoryContract;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class Auth0UserRepository implements Auth0UserRepositoryContract
 {
     /**
-     * @param \Auth0\Login\Contract\stdClass $jwt
+     * @param array $decodedJwt
      *
      * @return Auth0JWTUser
      */
-    public function getUserByDecodedJWT($jwt)
+    public function getUserByDecodedJWT(array $decodedJwt) : Authenticatable
     {
-        return new Auth0JWTUser($jwt);
+        return new Auth0JWTUser($decodedJwt);
     }
 
     /**
@@ -23,23 +24,23 @@ class Auth0UserRepository implements Auth0UserRepositoryContract
      *
      * @return Auth0User
      */
-    public function getUserByUserInfo($userInfo)
+    public function getUserByUserInfo(array $userInfo) : Authenticatable
     {
         return new Auth0User($userInfo['profile'], $userInfo['accessToken']);
     }
 
     /**
-     * @param \Auth0\Login\Contract\the $identifier
+     * @param string|int|null $identifier
      *
-     * @return Auth0User|\Illuminate\Contracts\Auth\Authenticatable|null
+     * @return Authenticatable|null
      */
-    public function getUserByIdentifier($identifier)
+    public function getUserByIdentifier($identifier) : ?Authenticatable
     {
         // Get the user info of the user logged in (probably in session)
         $user = \App::make('auth0')->getUser();
 
         if ($user === null) {
-            return;
+            return null;
         }
 
         // Build the user

--- a/tests/Auth0ServiceTest.php
+++ b/tests/Auth0ServiceTest.php
@@ -90,7 +90,7 @@ class Auth0ServiceTest extends OrchestraTestCase
     {
         $this->assertTrue(\Auth('auth0')->guest());
 
-        $user = new Auth0JWTUser((object)['sub' => 'x']);
+        $user = new Auth0JWTUser(['sub' => 'x']);
 
         \Auth('auth0')->setUser($user);
 

--- a/tests/Unit/Auth0JWTUserTest.php
+++ b/tests/Unit/Auth0JWTUserTest.php
@@ -15,7 +15,7 @@ class Auth0JWTUserTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->auth0JwtUser = new Auth0JWTUser((object)[
+        $this->auth0JwtUser = new Auth0JWTUser([
             "name" => "John Doe",
             "iss" => "http://auth0.com",
             "sub" => "someone@example.com",


### PR DESCRIPTION
### Changes

- **Breaking:** `Auth0JWTUser` and `Auth0User` constructors now require an array
- **Breaking:** `\Auth0\Login\Auth0Service::decodeJWT()` now returns an array
- `Auth0\Login\Contract` now declares param and return types