### PR TITLE
Fix access token validation

### DIFF
--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -173,15 +173,15 @@ class Auth0Service
      */
     public function decodeJWT($encUser, array $verifierOptions = [])
     {
-        $token_issuer  = 'https://'.$this->auth0Config['domain'].'/';
+        $token_issuer = 'https://'.$this->auth0Config['domain'].'/';
         $apiIdentifier = $this->auth0Config['api_identifier'];
         $idTokenAlg = $this->auth0Config['supported_algs'][0] ?? 'RS256';
 
         $signature_verifier = null;
         if ('RS256' === $idTokenAlg) {
-            $jwksUri       = $this->auth0Config['jwks_uri'] ?? 'https://'.$this->auth0Config['domain'].'/.well-known/jwks.json';
+            $jwksUri = $this->auth0Config['jwks_uri'] ?? 'https://'.$this->auth0Config['domain'].'/.well-known/jwks.json';
             $jwks_fetcher = new JWKFetcher($this->auth0Config['cache_handler']);
-            $jwks        = $jwks_fetcher->getKeys($jwksUri);
+            $jwks = $jwks_fetcher->getKeys($jwksUri);
             $signature_verifier = new AsymmetricVerifier($jwks);
         } else if ('HS256' === $idTokenAlg) {
             $signature_verifier = new SymmetricVerifier($this->auth0Config['client_secret']);

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -6,7 +6,7 @@ use Auth0\SDK\Auth0;
 use Auth0\SDK\Helpers\JWKFetcher;
 use Auth0\SDK\Helpers\Tokens\AsymmetricVerifier;
 use Auth0\SDK\Helpers\Tokens\SymmetricVerifier;
-use Auth0\SDK\Helpers\Tokens\IdTokenVerifier;
+use Auth0\SDK\Helpers\Tokens\TokenVerifier;
 use Auth0\SDK\Store\StoreInterface;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 use Illuminate\Http\RedirectResponse;
@@ -188,7 +188,7 @@ class Auth0Service
         }
 
         // Use IdTokenVerifier since Auth0-issued JWTs contain the 'sub' claim, which is used by the Laravel user model
-        $token_verifier = new IdTokenVerifier(
+        $token_verifier = new TokenVerifier(
             $token_issuer,
             $apiIdentifier,
             $signature_verifier

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -3,6 +3,7 @@
 namespace Auth0\Login;
 
 use Auth0\SDK\Auth0;
+use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Helpers\JWKFetcher;
 use Auth0\SDK\Helpers\Tokens\AsymmetricVerifier;
 use Auth0\SDK\Helpers\Tokens\SymmetricVerifier;
@@ -185,6 +186,8 @@ class Auth0Service
             $signature_verifier = new AsymmetricVerifier($jwks);
         } else if ('HS256' === $idTokenAlg) {
             $signature_verifier = new SymmetricVerifier($this->auth0Config['client_secret']);
+        } else {
+            throw new InvalidTokenException('Unsupported token signing algorithm configured. Must be either RS256 or HS256.');
         }
 
         // Use IdTokenVerifier since Auth0-issued JWTs contain the 'sub' claim, which is used by the Laravel user model

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -173,21 +173,17 @@ class Auth0Service
      */
     public function decodeJWT($encUser, array $verifierOptions = [])
     {
-
-        // TODO - check if config values are set and throw for those that are required
         $token_issuer  = 'https://'.$this->auth0Config['domain'].'/';
         $apiIdentifier = $this->auth0Config['api_identifier'];
+        $idTokenAlg = $this->auth0Config['supported_algs'][0] ?? 'RS256';
 
         $signature_verifier = null;
-        $idTokenAlg = $this->auth0Config['id_token_alg'] ?? 'RS256';
-
         if ('RS256' === $idTokenAlg) {
             $jwksUri       = $this->auth0Config['jwks_uri'] ?? 'https://'.$this->auth0Config['domain'].'/.well-known/jwks.json';
             $jwks_fetcher = new JWKFetcher($this->auth0Config['cache_handler']);
             $jwks        = $jwks_fetcher->getKeys($jwksUri);
             $signature_verifier = new AsymmetricVerifier($jwks);
         } else if ('HS256' === $idTokenAlg) {
-            // TODO - client_secret not being set in config?
             $signature_verifier = new SymmetricVerifier($this->auth0Config['client_secret']);
         }
 
@@ -197,8 +193,8 @@ class Auth0Service
             $apiIdentifier,
             $signature_verifier
         );
-        
-        $this->apiuser = $token_verifier->verify($encUser);
+
+        $this->apiuser = $token_verifier->verify($encUser, $verifierOptions);
         return $this->apiuser;
     }
 

--- a/tests/Auth0ServiceTest.php
+++ b/tests/Auth0ServiceTest.php
@@ -24,6 +24,7 @@ class Auth0ServiceTest extends OrchestraTestCase
             'client_secret' => '__test_client_secret__',
             'redirect_uri' => 'https://example.com/callback',
             'transient_store' => new SessionStore(),
+            'api_identifier' => 'https://example-audience.com'
         ];
     }
 

--- a/tests/Unit/Auth0ServiceUnitTest.php
+++ b/tests/Unit/Auth0ServiceUnitTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Auth0\Login\Tests\Unit;
+
+use Auth0\Login\Auth0Service;
+use PHPUnit\Framework\TestCase;
+use Auth0\SDK\Store\SessionStore;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Signer\Hmac\Sha256 as HsSigner;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Token;
+
+class Auth0ServiceTest extends TestCase
+{
+    public static $defaultConfig;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        self::$defaultConfig = [
+            'domain' => '__test_domain__',
+            'client_id' => '__test_client_id__',
+            'client_secret' => '__test_secret__',
+            'redirect_uri' => 'https://example.com/callback',
+            'transient_store' => new SessionStore(),
+            'api_identifier' => '__test_api_identifier__',
+            'supported_algs' => ['HS256']    
+        ];
+    }
+
+    public function testDecodeJWTReturnsDecodedJWT()
+    {
+        $service = new Auth0Service(self::$defaultConfig);
+        
+        $claims = [
+            'sub' => '__test_sub__',
+            'iss' => 'https://__test_domain__/',
+            'aud' => '__test_api_identifier__',
+            'azp' => '__test_azp__',
+            'exp' => time() + 1000,
+            'iat' => time() - 1000,
+        ];
+
+        $builder = new Builder();
+
+        foreach ($claims as $claim => $value) {
+            $builder->withClaim($claim, $value);
+        }
+
+        $token = $builder->getToken(new HsSigner(), new Key('__test_secret__'));
+        
+        $this->assertNotEmpty($service->decodeJWT($token));
+    }
+}

--- a/tests/Unit/Auth0ServiceUnitTest.php
+++ b/tests/Unit/Auth0ServiceUnitTest.php
@@ -3,12 +3,13 @@
 namespace Auth0\Login\Tests\Unit;
 
 use Auth0\Login\Auth0Service;
-use PHPUnit\Framework\TestCase;
+use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Store\SessionStore;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Signer\Hmac\Sha256 as HsSigner;
 use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Token;
+use PHPUnit\Framework\TestCase;
 
 class Auth0ServiceTest extends TestCase
 {
@@ -31,8 +32,24 @@ class Auth0ServiceTest extends TestCase
     public function testDecodeJWTReturnsDecodedJWT()
     {
         $service = new Auth0Service(self::$defaultConfig);
+        $token = self::getToken();
         
-        $claims = [
+        $this->assertNotEmpty($service->decodeJWT($token));
+    }
+
+    public function testThatInvalidTokenExceptionThrownForUnsupportedAlg()
+    {
+        $service = new Auth0Service(['supported_algs' => ['HS512']] + self::$defaultConfig);
+        $token = self::getToken();
+
+        $this->expectException(InvalidTokenException::class);
+        $service->decodeJWT($token);
+    }
+
+    private static function getToken()
+    {
+        $builder = new Builder();
+        $defaultClaims = [
             'sub' => '__test_sub__',
             'iss' => 'https://__test_domain__/',
             'aud' => '__test_api_identifier__',
@@ -41,14 +58,10 @@ class Auth0ServiceTest extends TestCase
             'iat' => time() - 1000,
         ];
 
-        $builder = new Builder();
-
-        foreach ($claims as $claim => $value) {
+        foreach ($defaultClaims as $claim => $value) {
             $builder->withClaim($claim, $value);
         }
 
-        $token = $builder->getToken(new HsSigner(), new Key('__test_secret__'));
-        
-        $this->assertNotEmpty($service->decodeJWT($token));
+        return $builder->getToken(new HsSigner(), new Key('__test_secret__'));
     }
 }


### PR DESCRIPTION
### Changes

Fixes `decodeJWT` to decode JWT access tokens:
- Uses `IdTokenVerifier` from auth0-php, since Auth0-issued JWTs contain a `sub` claim and this is used by the Laravel user model. 
- Determines the signature verifier to use via the `supported_algs` config; defaults to RS256.

### Testing

Would like to add additional unit tests, either as a follow-up commit or separate PR. Would be good to use a mock and confirm that the `verify` API is called with the configured options as we'd expect, but the `IdTokenVerifier` class is marked as `final`, so another approach will have to be taken.

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
