### PR TITLE
fix comnposer.json whitespace issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "php": "^7.1",
         "auth0/auth0-php": "^7.2.0",
-        "illuminate/support": "5.* | ^6.0 | ^7.0 | ^8.0",
-        "illuminate/contracts": "5.* | ^6.0 | ^7.0 | ^8.0"
+        "illuminate/support": "5.* | ^6.0 | ^7.0 | ^8.0",
+        "illuminate/contracts": "5.* | ^6.0 | ^7.0 | ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7|^8|^9",


### PR DESCRIPTION
### Changes

#190 made a change to update `composer.json` to support Laravel 8. A whitespace issue is causing CI to fail, and verified locally when running any `composer` command:

```
[UnexpectedValueException]                                                
Could not parse version constraint ^7.0 : Invalid version string "^7.0 " 
```

### References

#190 

### Testing

[ ] This change has been tested on the latest version Laravel

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
