### PR TITLE
Only mark stale if waiting for response

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,13 +1,14 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 90
+daysUntilStale: 120
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
-daysUntilClose: 7
+daysUntilClose: 21
 
-# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: []
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+  - 'Waiting for Response'
 
 # Set to true to ignore issues with an assignee (defaults to false)
 exemptAssignees: true


### PR DESCRIPTION
This PR updates stalebot's configuration to [match](https://github.com/auth0/auth0-PHP/pull/474) that of the [PHP SDK repo](https://github.com/auth0/auth0-PHP/blob/master/.github/stale.yml); it will only mark issues as stale that have been labeled "waiting for response."