### PR TITLE
[SDK-2325] fix: Avoid throwing an error when calling getUserByUserInfo() during login callback event when the supplied profile is empty/null

### DIFF
--- a/src/controllers/Auth0Controller.php
+++ b/src/controllers/Auth0Controller.php
@@ -35,7 +35,7 @@ class Auth0Controller extends Controller
         $profile = $service->getUser();
 
         // Get the user related to the profile
-        $auth0User = $this->userRepository->getUserByUserInfo($profile);
+        $auth0User = $profile ? $this->userRepository->getUserByUserInfo($profile) : null;
 
         if ($auth0User) {
             // If we have a user, we are going to log them in, but if


### PR DESCRIPTION
In some cases, our Laravel plugin will return null when getUser() is called. We do not currently handle these instances correctly and instead throw an error when we take this null response and attempt to pass it to User::getUserByUserInfo(), which only accepts array values. [Reported here.](https://github.com/auth0/laravel-auth0/issues/198#issuecomment-772999411)