### PR TITLE
Pass `api_identifier` config as `audience` to Auth0\SDK\Auth0

### DIFF
--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -66,6 +66,11 @@ class Auth0Service
 
         $auth0Config['cache_handler'] = $cache;
 
+        if(isset($auth0Config['api_identifier'])) {
+            // Auth0\SDK\Auth0 is using `audience` to create a login link.
+            $auth0Config['audience'] = $auth0Config['api_identifier'];
+        }
+
         $this->auth0Config = $auth0Config;
         $this->auth0       = new Auth0($auth0Config);
     }


### PR DESCRIPTION
### Changes

Pass `api_identifier` config as `audience` to Auth0\SDK\Auth0 as well as adding it to Auth0\Login\Auth0Service::$authConfig with the `audience` key too. 

### References

closes #213 

@evansims 

### Testing

`App::make('auth0')->login(...)` now includes audience parameter in the link. 

- [x] This change has been tested on Laravel 8.3 and auth0/login 6.4

### Checklist


- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
