### PR TITLE
Remove the facade aliases usage since they can be removed/changed fro…

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,6 @@ parameters:
     checkGenericClassInNonGenericObjectType: false
     level: 2
     ignoreErrors:
-        - '#Call to an undefined static method Event::listen#'
         - '#Call to static method#'
     paths:
         - src

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -21,11 +21,11 @@ class LoginServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        \Auth::provider('auth0', function ($app, array $config) {
+        \Illuminate\Support\Facades\Auth::provider('auth0', function ($app, array $config) {
             return $app->make(Auth0UserProvider::class);
         });
 
-        \Auth::extend('auth0', function ($app, $name, $config) {
+        \Illuminate\Support\Facades\Auth::extend('auth0', function ($app, $name, $config) {
             return new RequestGuard(function (Request $request, Auth0UserProvider $provider) {
                 return $provider->retrieveByCredentials(['api_token' => $request->bearerToken()]);
             }, $app['request'], $app['auth']->createUserProvider($config['provider']));
@@ -73,14 +73,14 @@ class LoginServiceProvider extends ServiceProvider
         });
 
         // When Laravel logs out, logout the auth0 SDK trough the service
-        \Event::listen('auth.logout', function () {
-            \App::make('auth0')->logout();
+        \Illuminate\Support\Facades\Event::listen('auth.logout', function () {
+            \Illuminate\Support\Facades\App::make('auth0')->logout();
         });
-        \Event::listen('user.logout', function () {
-            \App::make('auth0')->logout();
+        \Illuminate\Support\Facades\Event::listen('user.logout', function () {
+            \Illuminate\Support\Facades\App::make('auth0')->logout();
         });
-        \Event::listen('Illuminate\Auth\Events\Logout', function () {
-            \App::make('auth0')->logout();
+        \Illuminate\Support\Facades\Event::listen('Illuminate\Auth\Events\Logout', function () {
+            \Illuminate\Support\Facades\App::make('auth0')->logout();
         });
     }
 }

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -9,6 +9,8 @@ use Auth0\SDK\API\Helpers\InformationHeaders;
 use Auth0\SDK\Store\StoreInterface;
 use Illuminate\Auth\RequestGuard;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 class LoginServiceProvider extends ServiceProvider
@@ -21,11 +23,11 @@ class LoginServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        \Illuminate\Support\Facades\Auth::provider('auth0', function ($app, array $config) {
+        Auth::provider('auth0', function ($app, array $config) {
             return $app->make(Auth0UserProvider::class);
         });
 
-        \Illuminate\Support\Facades\Auth::extend('auth0', function ($app, $name, $config) {
+        Auth::extend('auth0', function ($app, $name, $config) {
             return new RequestGuard(function (Request $request, Auth0UserProvider $provider) {
                 return $provider->retrieveByCredentials(['api_token' => $request->bearerToken()]);
             }, $app['request'], $app['auth']->createUserProvider($config['provider']));
@@ -73,14 +75,14 @@ class LoginServiceProvider extends ServiceProvider
         });
 
         // When Laravel logs out, logout the auth0 SDK trough the service
-        \Illuminate\Support\Facades\Event::listen('auth.logout', function () {
-            \Illuminate\Support\Facades\App::make('auth0')->logout();
+        Event::listen('auth.logout', function () {
+            app('auth0')->logout();
         });
-        \Illuminate\Support\Facades\Event::listen('user.logout', function () {
-            \Illuminate\Support\Facades\App::make('auth0')->logout();
+        Event::listen('user.logout', function () {
+            app('auth0')->logout();
         });
-        \Illuminate\Support\Facades\Event::listen('Illuminate\Auth\Events\Logout', function () {
-            \Illuminate\Support\Facades\App::make('auth0')->logout();
+        Event::listen('Illuminate\Auth\Events\Logout', function () {
+            app('auth0')->logout();
         });
     }
 }

--- a/src/Auth0/Login/Repository/Auth0UserRepository.php
+++ b/src/Auth0/Login/Repository/Auth0UserRepository.php
@@ -37,7 +37,7 @@ class Auth0UserRepository implements Auth0UserRepositoryContract
     public function getUserByIdentifier($identifier) : ?Authenticatable
     {
         // Get the user info of the user logged in (probably in session)
-        $user = \Illuminate\Support\Facades\App::make('auth0')->getUser();
+        $user = app('auth0')->getUser();
 
         if ($user === null) {
             return null;

--- a/src/Auth0/Login/Repository/Auth0UserRepository.php
+++ b/src/Auth0/Login/Repository/Auth0UserRepository.php
@@ -37,7 +37,7 @@ class Auth0UserRepository implements Auth0UserRepositoryContract
     public function getUserByIdentifier($identifier) : ?Authenticatable
     {
         // Get the user info of the user logged in (probably in session)
-        $user = \App::make('auth0')->getUser();
+        $user = \Illuminate\Support\Facades\App::make('auth0')->getUser();
 
         if ($user === null) {
             return null;


### PR DESCRIPTION
### Changes

Use the fully qualified facade class names instead of their aliases which allow using the plugin even when for some reason the default aliases have been removed or replaced (ie. legacy code usage).

### Testing

[x] This change has been tested on the latest version Laravel

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
