### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Note that Organizations is currently only available to customers on our Enterpri
 
 #### Logging in with an Organization
 
-Open your Auth0 Laravel plugin configuration file (usually `config/laravel-auth0.php`) uncomment the `organization` optiion and specify the Id for your Organization (found in your Organization settings on the Auth0 Dashboard.)
+Open your Auth0 Laravel plugin configuration file (usually `config/laravel-auth0.php`) uncomment the `organization` option and specify the Id for your Organization (found in your Organization settings on the Auth0 Dashboard.)
 
 ```php
 // config/laravel-auth0.php


### PR DESCRIPTION
### Changes

Fixed a typo in README.md. The word 'option' was spelled with two 'i'.

### References

I don't believe any reference is needed. If I'm incorrect, I'll gladly open an issue and update this PR with a reference to it.

### Testing

This isn't modifying any code, so testing is not applicable IMO.

[x] This change has been tested on the latest version Laravel

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
