### PR TITLE
Laravel Octane Support

### DIFF
--- a/src/Auth0/Login/Auth0.php
+++ b/src/Auth0/Login/Auth0.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Auth0\Login;
+
+use Auth0\SDK\Auth0 as BaseAuth0;
+
+class Auth0 extends BaseAuth0
+{
+    protected function getAuthorizationCode()
+    {
+        $code    = request()->get('code');
+        $hasCode = request()->has('code');
+
+        if ($this->responseMode === 'query' && $hasCode) {
+            $code = request()->get('code');
+        } elseif ($this->responseMode === 'form_post' && $hasCode) {
+            $code = request()->post('code');
+        }
+
+        return $code;
+    }
+
+    public function getState()
+    {
+        $state = null;
+        $hasStateKey = request()->has(self::TRANSIENT_STATE_KEY);
+
+        if ($this->responseMode === 'query' && $hasStateKey) {
+            $state = request()->get(self::TRANSIENT_STATE_KEY);
+        } else if ($this->responseMode === 'form_post' && $hasStateKey) {
+            $state = request()->post(self::TRANSIENT_STATE_KEY);
+        }
+
+        return $state;
+    }
+
+    public function getInvitationParameters()
+    {
+        $invite  = null;
+        $orgId   = null;
+        $orgName = null;
+
+        $invitation = request()->get('invitation');
+        $organization = request()->get('organization');
+        $organizationName = request()->get('organization_name');
+
+        if ($this->responseMode === 'query') {
+            $invite  = ($invitation ? filter_var($invitation, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE) : null);
+            $orgId   = ($organization ? filter_var($organization, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE) : null);
+            $orgName = ($organizationName ? filter_var($organizationName, FILTER_SANITIZE_STRING, FILTER_NULL_ON_FAILURE) : null);
+        }
+
+        if ($invite && $orgId && $orgName) {
+            return (object) [
+                'invitation' => $invite,
+                'organization' => $orgId,
+                'organizationName' => $orgName
+            ];
+        }
+
+        return null;
+    }
+}

--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -2,7 +2,7 @@
 
 namespace Auth0\Login;
 
-use Auth0\SDK\Auth0;
+use Auth0\Login\Auth0;
 use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Helpers\JWKFetcher;
 use Auth0\SDK\Helpers\Tokens\AsymmetricVerifier;

--- a/src/Auth0/Login/LoginServiceProvider.php
+++ b/src/Auth0/Login/LoginServiceProvider.php
@@ -63,14 +63,15 @@ class LoginServiceProvider extends ServiceProvider
         $this->app->bind(Auth0UserRepositoryContract::class, Auth0UserRepository::class);
 
         // Bind the auth0 name to a singleton instance of the Auth0 Service
-        $this->app->singleton(Auth0Service::class, function ($app) {
+        $this->app->bind(Auth0Service::class, function ($app) {
             return new Auth0Service(
                 $app->make('config')->get('laravel-auth0'),
                 $app->make(StoreInterface::class),
                 $app->make('cache.store')
             );
         });
-        $this->app->singleton('auth0', function () {
+
+        $this->app->bind('auth0', function () {
             return $this->app->make(Auth0Service::class);
         });
 


### PR DESCRIPTION
### Changes

A code changes that relates to Laravel Octane support. Please see change files for more info.

### References

See: https://github.com/auth0/laravel-auth0/issues/212

### Testing

Recommend to test it in a Laravel Octane server.


### Note
When binding `Auth0UserRepository` contract in your `AppServiceProvider`, the second parameter should be a closure returning the concrete class. See example below:

```php
$this->app->bind(
    \Auth0\Login\Contract\Auth0UserRepository::class,
    function() {
        return new \Auth0\Login\Repository\Auth0UserRepository();
    }
);
```