### PR TITLE
Add an array type check within the callOnLogin callback

### DIFF
--- a/src/Auth0/Login/Auth0Service.php
+++ b/src/Auth0/Login/Auth0Service.php
@@ -233,11 +233,14 @@ class Auth0Service
         $user = call_user_func($this->onLoginCb, $auth0User);
 
         if(is_array($user) || method_exists($user, 'toArray')) {
-            if(!is_array($user)) $array = $user->toArray();
-            else $array = $user;
+            if(! is_array($user)) {
+                $array = $user->toArray();
+            } else {
+                $array = $user;
+            }
 
             $this->getSDK()->setUser($array);
-        }   
+        }
 
         return $user;
     }


### PR DESCRIPTION
Fixes the onLogin callback bug relating to Authenticatable / array types. 


### Changes

Updates how the Auth0Service class handles the callOnLogin callback return. 

A bug added in #206 directly set whatever was returned from a custom `onLogin` handler to the `setUser()`. 

The `callOnLogin` method is passed an `Authenticatable` object, and needs to return the same for the later `Auth::login` in the calling controllers to work. The `setUser()` call expects an array to be passed. 

This checks if what's returned from the custom `onLogin` handler is an array, or an object that can be cast to an array, and passes that to the setUser method. 

Returns the object returned from the callback directly to the parent service regardless.

### References

Resolves #227  introduced in #206


### Testing


To test - you need to make use of the `onLogin` callback. 

For testing you can define this in your routes against the Auth0 service like so: 

```
Auth0::onLogin(function ($auth0User) {
    $user = User::where('sub', $auth0User->getAuthIdentifier())->first();
    return $user;
});
```

This triggers the `if ($service->hasOnLogin())` check in `Auth0Controller.php` which calls our updated array/object check.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
