### PR TITLE
Setup test suite environment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# We use 4 space indentation for PHP
+[*.php]
+indent_style = space
+indent_size = 4

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,15 @@
+{
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection.log",
+        "perMutator": "infection.mutators.md"
+    },
+    "mutators": {
+        "@default": true
+    },
+    "testFramework": "pest"
+}

--- a/phpinsights.php
+++ b/phpinsights.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'preset' => 'default',
+    'ide' => null,
+
+    'exclude' => [
+        // 'path/to/directory-or-file'
+    ],
+
+    'add' => [
+        \NunoMaduro\PhpInsights\Domain\Metrics\Code\Comments::class => [
+            \SlevomatCodingStandard\Sniffs\Classes\RequireMultiLineMethodSignatureSniff::class,
+        ],
+    ],
+
+    'remove' => [
+        \NunoMaduro\PhpInsights\Domain\Insights\CyclomaticComplexityIsHigh::class,
+        \NunoMaduro\PhpInsights\Domain\Insights\ForbiddenGlobals::class,
+        \NunoMaduro\PhpInsights\Domain\Insights\ForbiddenNormalClasses::class,
+        \NunoMaduro\PhpInsights\Domain\Insights\ForbiddenTraits::class,
+        \NunoMaduro\PhpInsights\Domain\Sniffs\ForbiddenSetterSniff::class,
+        \ObjectCalisthenics\Sniffs\Files\ClassTraitAndInterfaceLengthSniff::class,
+        \ObjectCalisthenics\Sniffs\Files\FunctionLengthSniff::class,
+        \ObjectCalisthenics\Sniffs\Metrics\MethodPerClassLimitSniff::class,
+        \ObjectCalisthenics\Sniffs\Metrics\MaxNestingLevelSniff::class,
+        \PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff::class,
+        \PHP_CodeSniffer\Standards\Generic\Sniffs\Commenting\TodoSniff::class,
+        \SlevomatCodingStandard\Sniffs\Classes\SuperfluousExceptionNamingSniff::class,
+        \SlevomatCodingStandard\Sniffs\Classes\SuperfluousInterfaceNamingSniff::class,
+        \SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff::class,
+        \SlevomatCodingStandard\Sniffs\Functions\FunctionLengthSniff::class,
+        \SlevomatCodingStandard\Sniffs\TypeHints\DisallowMixedTypeHintSniff::class,
+        \SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff::class,
+        \SlevomatCodingStandard\Sniffs\TypeHints\PropertyTypeHintSniff::class,
+        \SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff::class,
+    ],
+
+    'config' => [
+        \PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DeprecatedFunctionsSniff::class => [
+            'exclude' => [
+                // 'src/Token/Verifier.php',
+            ],
+        ],
+        \SlevomatCodingStandard\Sniffs\Functions\UnusedParameterSniff::class => [
+            'exclude' => [
+                'src/ServiceProvider.php',
+            ],
+        ],
+        \SlevomatCodingStandard\Sniffs\Classes\ModernClassNameReferenceSniff::class => [
+            'exclude' => [
+                // 'src/Mixins/ConfigurableMixin.php',
+            ],
+        ],
+        \SlevomatCodingStandard\Sniffs\Classes\RequireMultiLineMethodSignatureSniff::class => [
+            'minLineLength' => '0',
+        ],
+    ],
+
+    'requirements' => [
+        'min-quality' => 100,
+        'min-complexity' => 50,
+        'min-architecture' => 100,
+        'min-style' => 100,
+        'disable-security-check' => false,
+    ],
+];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,30 @@
+includes:
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/ergebnis/phpstan-rules/rules.neon
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+
+parameters:
+    level: max
+
+    paths:
+        - src
+
+    bootstrapFiles:
+        - tests/constants.php
+
+    ignoreErrors:
+        - '#Function (app|auth|event|redirect) not found.#'
+        - '#Constructor in (.*) has parameter (.*) with default value.#'
+        - '#Constructor in (.*) has parameter (.*) with null as default value.#'
+        - '#Method (.*) has parameter (.*) with a nullable type declaration.#'
+        - '#Method (.*) has parameter (.*) with null as default value.#'
+        - '#Method (.*) has a nullable return type declaration.#'
+        - '#Language construct isset\(\) should not be used.#'
+        - '#Method (.*) has parameter (.*) with no value type specified in iterable type array.#'
+        - '#not allowed to extend#'
+        - '#no value type specified in iterable type array.#'
+        - '#is not final, but since the containing class is abstract, it should be.#'
+        - '#Class "Auth0\\Login\\Exception\\(.*)" is not allowed to extend "Exception".#'
+        - '#Class "Auth0\\Laravel\\Exception\\(.*)" is not allowed to extend "Exception".#'
+
+    reportUnmatchedIgnoredErrors: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,26 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Auth0 Laravel Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <ini name="session.use_cookies" value="false"/>
-        <ini name="session.cache_limiter" value="false"/>
-    </php>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" stderr="true" colors="true" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="error_reporting" value="E_ALL ^ E_DEPRECATED"/>
+    <ini name="session.use_cookies" value="false"/>
+    <ini name="session.cache_limiter" value="false"/>
+  </php>
 </phpunit>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+    </projectFiles>
+
+    <issueHandlers>
+        <InvalidStringClass errorLevel="suppress" />
+        <MixedArgument errorLevel="suppress" />
+        <MixedArgumentTypeCoercion errorLevel="suppress" />
+        <MixedArrayAccess errorLevel="suppress" />
+        <MixedAssignment errorLevel="suppress" />
+        <MixedInferredReturnType errorLevel="suppress" />
+        <MixedPropertyTypeCoercion errorLevel="suppress" />
+        <MixedReturnStatement errorLevel="suppress" />
+        <PossiblyNullArgument errorLevel="suppress" />
+        <PossiblyNullPropertyAssignmentValue errorLevel="suppress" />
+        <PossiblyNullReference errorLevel="suppress" />
+    </issueHandlers>
+</psalm>

--- a/tests/constants.php
+++ b/tests/constants.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Laravel polyfills, since we don't want to test against the complete framework suite,
+ * just fill in the method gaps with placeholders.
+ */
+
+if (! function_exists('auth')) {
+    function auth(... $params) {
+
+    }
+}
+
+if (! function_exists('abort')) {
+    function abort(... $params) {
+
+    }
+}


### PR DESCRIPTION
This PR sets up the initial test suite environment's configuration files, for porting the suite over from the Auth0-PHP parent library for use on the Laravel middleware. Does not introduce any new logic changes.