### PR TITLE
Composer package manifest updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,9 +71,6 @@ workflows:
   run-tests:
     jobs:
       - run-unit-tests:
-          name: run-phpunit-7.3
-          php: "7.3"
-      - run-unit-tests:
           name: run-phpunit-7.4
           php: "7.4"
       - run-unit-tests:
@@ -85,4 +82,4 @@ workflows:
               only:
                 - main
           context: snyk-env
-          requires: [run-phpunit-7.3]
+          requires: [run-phpunit-7.4]

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0/login",
-  "description": "Laravel plugin that helps authenticate with the Auth0 service",
+  "description": "Auth0 Laravel SDK. Straight-forward and tested methods for implementing authentication, and accessing Auth0's Management API endpoints.",
   "type": "library",
   "keywords": [
     "laravel",
@@ -29,23 +29,33 @@
     }
   ],
   "require": {
-    "php": "^7.3 || ^8.0",
-    "ext-json": "*",
-    "ext-openssl": "*",
+    "php": "^7.4 || ^8.0, <8.2",
     "ext-filter": "*",
+    "ext-json": "*",
     "ext-mbstring": "*",
-    "auth0/auth0-php": "^7.9",
-    "illuminate/support": " ^6.0 || ^7.0 || ^8.0",
-    "illuminate/contracts": "^6.0 || ^7.0 || ^8.0"
+    "ext-openssl": "*",
+    "auth0/auth0-php": "^8.0",
+    "illuminate/contracts": "^8.0 || ^9.0",
+    "illuminate/http": "^8.0 || ^9.0",
+    "illuminate/support": " ^8.0 || ^9.0",
+    "spatie/laravel-package-tools": "^1.9"
   },
   "require-dev": {
-    "nunomaduro/phpinsights": "^1.13 || ^2.0",
-    "phpunit/phpunit": "^9.5",
-    "orchestra/testbench": "^4.0 || ^5.0",
-    "nunomaduro/larastan": "^0.7"
-  },
-  "conflict": {
-    "lcobucci/jwt": "*"
+    "ergebnis/phpstan-rules": "^0.15",
+    "firebase/php-jwt": "^5.0",
+    "hyperf/event": "^2.2",
+    "infection/infection": "^0.23",
+    "mockery/mockery": "^1.4",
+    "nunomaduro/phpinsights": "^2.0",
+    "nyholm/psr7": "^1.4",
+    "pestphp/pest": "^1.18",
+    "pestphp/pest-plugin-parallel": "^0.2",
+    "php-http/mock-client": "^1.4",
+    "phpstan/phpstan": "^0.12",
+    "phpstan/phpstan-strict-rules": "^0.12",
+    "symfony/cache": "^4.4 || ^5.2",
+    "thecodingmachine/phpstan-strict-rules": "^0.12",
+    "vimeo/psalm": "^4.10"
   },
   "autoload": {
     "psr-4": {
@@ -60,10 +70,10 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Auth0\\Login\\LoginServiceProvider"
+        "Auth0\\Laravel\\ServiceProvider"
       ],
       "aliases": {
-        "Auth0": "Auth0\\Login\\Facade\\Auth0"
+        "Auth0": "Auth0\\Laravel\\Facade\\Auth0"
       }
     }
   },


### PR DESCRIPTION
This PR includes necessary changes to the Composer package manifest for v7 of the library, to facilitate the upgrade to Auth0-PHP 8 and new test suite conditions, and to point the PSR-4 class autodiscovery to the new class locations. No logic changes are included.

Note: This PR removes support for the now EOL'd PHP 7.3 runtime version, which is not supported by the upstream libraries either. PHP 7.4+ will only be supported in the new v7 major of the library.