### PR TITLE
Introduce Interfaces for library classes

### DIFF
--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -4,51 +4,35 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Auth;
 
-final class Guard implements \Illuminate\Contracts\Auth\Guard
+final class Guard implements \Illuminate\Contracts\Auth\Guard, \Auth0\Laravel\Contract\Auth\Guard
 {
     /**
      * The user provider implementation.
-     *
-     * @var \Illuminate\Contracts\Auth\UserProvider
      */
-    private $provider;
+    private \Illuminate\Contracts\Auth\UserProvider $provider;
 
     /**
      * The request instance.
-     *
-     * @var \Illuminate\Http\Request
      */
-    private $request;
+    private \Illuminate\Http\Request $request;
 
     /**
      * The name of the query string item from the request containing the API token.
-     *
-     * @var string
      */
-    private $inputKey;
+    private string $inputKey;
 
     /**
      * The name of the token "column" in persistent storage.
-     *
-     * @var string
      */
-    private $storageKey;
+    private string $storageKey;
 
     /**
      * Indicates if the API token is hashed in storage.
-     *
-     * @var bool
      */
-    private $hash = false;
+    private bool $hash = false;
 
     /**
-     * Create a new authentication guard.
-     *
-     * @param \Illuminate\Contracts\Auth\UserProvider $provider
-     * @param \Illuminate\Http\Request $request
-     * @param string $inputKey
-     * @param string $storageKey
-     * @param bool $hash
+     * @inheritdoc
      */
     public function __construct(
         \Illuminate\Contracts\Auth\UserProvider $provider,
@@ -65,9 +49,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Set the current user.
-     *
-     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     * @inheritdoc
      */
     public function login(
         \Illuminate\Contracts\Auth\Authenticatable $user
@@ -77,7 +59,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Clear the current user.
+     * @inheritdoc
      */
     public function logout(): self
     {
@@ -87,9 +69,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Determine if the current user is authenticated.
-     *
-     * @return bool
+     * @inheritdoc
      */
     public function check(): bool
     {
@@ -97,9 +77,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Determine if the current user is a guest.
-     *
-     * @return bool
+     * @inheritdoc
      */
     public function guest(): bool
     {
@@ -107,9 +85,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Get the ID for the currently authenticated user.
-     *
-     * @return int|string|null
+     * @inheritdoc
      */
     public function id()
     {
@@ -127,9 +103,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Validate a user's credentials.
-     *
-     * @param array $credentials
+     * @inheritdoc
      */
     public function validate(
         array $credentials = []
@@ -144,7 +118,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Determine if the guard has a user instance.
+     * @inheritdoc
      */
     public function hasUser(): bool
     {
@@ -152,9 +126,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Set the current user.
-     *
-     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     *  @inheritdoc
      */
     public function setUser(
         \Illuminate\Contracts\Auth\Authenticatable $user
@@ -164,9 +136,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Set the current request instance.
-     *
-     * @param \Illuminate\Http\Request $request
+     * @inheritdoc
      */
     public function setRequest(
         \Illuminate\Http\Request $request
@@ -176,7 +146,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Get the currently authenticated user.
+     * @inheritdoc
      */
     public function user(): ?\Illuminate\Contracts\Auth\Authenticatable
     {
@@ -207,7 +177,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
     }
 
     /**
-     * Get the token for the current request.
+     * @inheritdoc
      */
     public function getTokenForRequest(): ?string
     {
@@ -232,6 +202,9 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard
         return null;
     }
 
+    /**
+     * Return the current request's StateInstance singleton.
+     */
     private function getInstance(): \Auth0\Laravel\StateInstance
     {
         return app()->make(\Auth0\Laravel\StateInstance::class);

--- a/src/Auth/User/Provider.php
+++ b/src/Auth/User/Provider.php
@@ -4,23 +4,24 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Auth\User;
 
-final class Provider implements \Illuminate\Contracts\Auth\UserProvider
+final class Provider implements \Illuminate\Contracts\Auth\UserProvider, \Auth0\Laravel\Contract\Auth\User\Provider
 {
+    /**
+     * A repository instance.
+     */
     private Repository $repository;
 
     /**
-     * Auth0UserProvider constructor.
-     *
-     * @param \Auth0\Laravel\Auth\User\Repository $repository
+     * @inheritdoc
      */
     public function __construct(
-        Repository $repository
+        \Auth0\Laravel\Auth\User\Repository $repository
     ) {
         $this->repository = $repository;
     }
 
     /**
-     * Returns a \Auth0\Laravel\Model\Stateless\User instance from an Id Token.
+     * @inheritdoc
      */
     public function retrieveById(
         $identifier
@@ -45,7 +46,7 @@ final class Provider implements \Illuminate\Contracts\Auth\UserProvider
     }
 
     /**
-     * Returns a \Auth0\Laravel\Model\Stateless\User instance from an Access Token.
+     * @inheritdoc
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */
@@ -68,7 +69,7 @@ final class Provider implements \Illuminate\Contracts\Auth\UserProvider
     }
 
     /**
-     * Returns a \Auth0\Laravel\Model\Stateless\User instance translated from an Auth0-PHP SDK session.
+     * @inheritdoc
      */
     public function retrieveByCredentials(
         array $credentials
@@ -85,7 +86,7 @@ final class Provider implements \Illuminate\Contracts\Auth\UserProvider
     }
 
     /**
-     * Returns true if the provided $user's unique identifier matches the credentials payload.
+     * @inheritdoc
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */
@@ -97,7 +98,7 @@ final class Provider implements \Illuminate\Contracts\Auth\UserProvider
     }
 
     /**
-     * Method required by interface. Not supported.
+     * @inheritdoc
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */

--- a/src/Auth/User/Repository.php
+++ b/src/Auth/User/Repository.php
@@ -4,18 +4,10 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Auth\User;
 
-final class Repository
+final class Repository implements \Auth0\Laravel\Contract\Auth\User\Repository
 {
     /**
-     * Generate a \Auth0\Laravel\Model\Stateful\User instance from an available Auth0-PHP user session.
-     *
-     * @param array       $profile               An array containing the raw Auth0 user data.
-     * @param string|null $idToken               An ID Token used by the user context. Null when unavailable.
-     * @param string|null $accessToken           An Access Token used by the user context. Null when unavailable.
-     * @param array|null  $accessTokenScope      An array of scopes requested/returned during authentication for the user context. Null when unavailable.
-     * @param int|null    $accessTokenExpiration A unix timestamp representing when an access token expires, if available.
-     * @param bool|null   $accessTokenExpired    Returns true if the access token has expired, if an expiration timestamp was available.
-     * @param string|null $refreshToken          A Refresh Token used by the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function fromSession(
         array $profile,
@@ -38,15 +30,7 @@ final class Repository
     }
 
     /**
-     * Generate a \Auth0\Laravel\Model\Stateful\User instance from a parsed Access Token.
-     *
-     * @param array       $profile               An array containing the raw Auth0 user data.
-     * @param string|null $idToken               An ID Token used by the user context. Null when unavailable.
-     * @param string|null $accessToken           An Access Token used by the user context. Null when unavailable.
-     * @param array|null  $accessTokenScope      An array of scopes requested/returned during authentication for the user context. Null when unavailable.
-     * @param int|null    $accessTokenExpiration A unix timestamp representing when an access token expires, if available.
-     * @param bool|null   $accessTokenExpired    Returns true if the access token has expired, if an expiration timestamp was available.
-     * @param string|null $refreshToken          A Refresh Token used by the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function fromAccessToken(
         array $profile,
@@ -69,15 +53,7 @@ final class Repository
     }
 
     /**
-     * Generate a \Auth0\Laravel\Model\Stateful\User instance from a parsed ID Token.
-     *
-     * @param array       $profile               An array containing the raw Auth0 user data.
-     * @param string|null $idToken               An ID Token used by the user context. Null when unavailable.
-     * @param string|null $accessToken           An Access Token used by the user context. Null when unavailable.
-     * @param array|null  $accessTokenScope      An array of scopes requested/returned during authentication for the user context. Null when unavailable.
-     * @param int|null    $accessTokenExpiration A unix timestamp representing when an access token expires, if available.
-     * @param bool|null   $accessTokenExpired    Returns true if the access token has expired, if an expiration timestamp was available.
-     * @param string|null $refreshToken          A Refresh Token used by the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function fromIdToken(
         array $profile,

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -7,7 +7,7 @@ namespace Auth0\Laravel;
 /**
  * Service that provides access to the Auth0 SDK.
  */
-final class Auth0
+final class Auth0 implements \Auth0\Laravel\Contract\Auth0
 {
     /**
      * The Laravel-Auth0 SDK version:
@@ -25,7 +25,7 @@ final class Auth0
     private ?\Auth0\SDK\Configuration\SdkConfiguration $configuration = null;
 
     /**
-     * Create/return instance of the Auth0-PHP SDK.
+     * @inheritdoc
      */
     public function getSdk(): \Auth0\SDK\Auth0
     {
@@ -37,7 +37,17 @@ final class Auth0
     }
 
     /**
-     * Create/return instance of the Auth0-PHP SdkConfiguration.
+     * @inheritdoc
+     */
+    public function setSdk(
+        \Auth0\SDK\Auth0 $sdk
+    ): self {
+        $this->sdk = $sdk;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
      */
     public function getConfiguration(): \Auth0\SDK\Configuration\SdkConfiguration
     {
@@ -49,7 +59,17 @@ final class Auth0
     }
 
     /**
-     * Create/create a request state instance, a storage singleton containing authenticated user data.
+     * @inheritdoc
+     */
+    public function setConfiguration(
+        \Auth0\SDK\Configuration\SdkConfiguration $configuration
+    ): self {
+        $this->configuration = $configuration;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
      */
     public function getState(): \Auth0\Laravel\StateInstance
     {

--- a/src/Contract/Auth/Guard.php
+++ b/src/Contract/Auth/Guard.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Auth;
+
+interface Guard
+{
+    /**
+     * Create a new authentication guard.
+     *
+     * @param \Illuminate\Contracts\Auth\UserProvider $provider
+     * @param \Illuminate\Http\Request $request
+     * @param string $inputKey
+     * @param string $storageKey
+     * @param bool $hash
+     */
+    public function __construct(
+        \Illuminate\Contracts\Auth\UserProvider $provider,
+        \Illuminate\Http\Request $request,
+        $inputKey = 'api_token',
+        $storageKey = 'api_token',
+        $hash = false
+    );
+
+    /**
+     * Set the current user.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     */
+    public function login(
+        \Illuminate\Contracts\Auth\Authenticatable $user
+    ): self;
+
+    /**
+     * Clear the current user.
+     */
+    public function logout(): self;
+
+    /**
+     * Determine if the current user is authenticated.
+     *
+     * @return bool
+     */
+    public function check(): bool;
+
+    /**
+     * Determine if the current user is a guest.
+     *
+     * @return bool
+     */
+    public function guest(): bool;
+
+    /**
+     * Get the ID for the currently authenticated user.
+     *
+     * @return int|string|null
+     */
+    public function id();
+
+    /**
+     * Validate a user's credentials.
+     *
+     * @param array $credentials
+     */
+    public function validate(
+        array $credentials = []
+    ): bool;
+
+    /**
+     * Determine if the guard has a user instance.
+     */
+    public function hasUser(): bool;
+
+    /**
+     * Set the current user.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     */
+    public function setUser(
+        \Illuminate\Contracts\Auth\Authenticatable $user
+    ): self;
+
+    /**
+     * Set the current request instance.
+     *
+     * @param \Illuminate\Http\Request $request
+     */
+    public function setRequest(
+        \Illuminate\Http\Request $request
+    ): self;
+
+    /**
+     * Get the currently authenticated user.
+     */
+    public function user(): ?\Illuminate\Contracts\Auth\Authenticatable;
+
+    /**
+     * Get the token for the current request.
+     */
+    public function getTokenForRequest(): ?string;
+}

--- a/src/Contract/Auth/User/Provider.php
+++ b/src/Contract/Auth/User/Provider.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Auth\User;
+
+interface Provider
+{
+    /**
+     * Auth0UserProvider constructor.
+     *
+     * @param \Auth0\Laravel\Auth\User\Repository $repository A repository instance.
+     */
+    public function __construct(
+        \Auth0\Laravel\Auth\User\Repository $repository
+    );
+
+    /**
+     * Returns a \Auth0\Laravel\Model\Stateless\User instance from an Id Token.
+     *
+     * @param string $identifier A string representing the encoded Id Token.
+     */
+    public function retrieveById(
+        $identifier
+    ): ?\Illuminate\Contracts\Auth\Authenticatable;
+
+    /**
+     * Returns a \Auth0\Laravel\Model\Stateless\User instance from an Access Token.
+     *
+     * @param mixed  $identifier Unused in this provider.
+     * @param string $token      A string representing the encoded Access Token.
+     */
+    public function retrieveByToken(
+        $identifier,
+        $token
+    ): ?\Illuminate\Contracts\Auth\Authenticatable;
+
+    /**
+     * Returns a \Auth0\Laravel\Model\Stateless\User instance translated from an Auth0-PHP SDK session.
+     */
+    public function retrieveByCredentials(
+        array $credentials
+    ): ?\Illuminate\Contracts\Auth\Authenticatable;
+
+    /**
+     * Returns true if the provided $user's unique identifier matches the credentials payload.
+     */
+    public function validateCredentials(
+        \Illuminate\Contracts\Auth\Authenticatable $user,
+        array $credentials
+    ): bool;
+
+    /**
+     * Method required by interface. Not supported.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user  User context.
+     * @param string                                     $token A string representing the remember token.
+     */
+    public function updateRememberToken(
+        \Illuminate\Contracts\Auth\Authenticatable $user,
+        $token
+    ): void;
+}

--- a/src/Contract/Auth/User/Repository.php
+++ b/src/Contract/Auth/User/Repository.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Auth\User;
+
+interface Repository
+{
+    /**
+     * Generate a \Auth0\Laravel\Model\Stateful\User instance from an available Auth0-PHP user session.
+     *
+     * @param array       $profile               An array containing the raw Auth0 user data.
+     * @param string|null $idToken               An ID Token used by the user context. Null when unavailable.
+     * @param string|null $accessToken           An Access Token used by the user context. Null when unavailable.
+     * @param array|null  $accessTokenScope      An array of scopes requested/returned during authentication for the user context. Null when unavailable.
+     * @param int|null    $accessTokenExpiration A unix timestamp representing when an access token expires, if available.
+     * @param bool|null   $accessTokenExpired    Returns true if the access token has expired, if an expiration timestamp was available.
+     * @param string|null $refreshToken          A Refresh Token used by the user context. Null when unavailable.
+     */
+    public function fromSession(
+        array $profile,
+        ?string $idToken,
+        ?string $accessToken,
+        ?array $accessTokenScope,
+        ?int $accessTokenExpiration,
+        ?bool $accessTokenExpired,
+        ?string $refreshToken
+    ): \Illuminate\Contracts\Auth\Authenticatable;
+
+    /**
+     * Generate a \Auth0\Laravel\Model\Stateful\User instance from a parsed Access Token.
+     *
+     * @param array       $profile               An array containing the raw Auth0 user data.
+     * @param string|null $idToken               An ID Token used by the user context. Null when unavailable.
+     * @param string|null $accessToken           An Access Token used by the user context. Null when unavailable.
+     * @param array|null  $accessTokenScope      An array of scopes requested/returned during authentication for the user context. Null when unavailable.
+     * @param int|null    $accessTokenExpiration A unix timestamp representing when an access token expires, if available.
+     * @param bool|null   $accessTokenExpired    Returns true if the access token has expired, if an expiration timestamp was available.
+     * @param string|null $refreshToken          A Refresh Token used by the user context. Null when unavailable.
+     */
+    public function fromAccessToken(
+        array $profile,
+        ?string $idToken,
+        ?string $accessToken,
+        ?array $accessTokenScope,
+        ?int $accessTokenExpiration,
+        ?bool $accessTokenExpired,
+        ?string $refreshToken
+    ): \Illuminate\Contracts\Auth\Authenticatable;
+
+    /**
+     * Generate a \Auth0\Laravel\Model\Stateful\User instance from a parsed ID Token.
+     *
+     * @param array       $profile               An array containing the raw Auth0 user data.
+     * @param string|null $idToken               An ID Token used by the user context. Null when unavailable.
+     * @param string|null $accessToken           An Access Token used by the user context. Null when unavailable.
+     * @param array|null  $accessTokenScope      An array of scopes requested/returned during authentication for the user context. Null when unavailable.
+     * @param int|null    $accessTokenExpiration A unix timestamp representing when an access token expires, if available.
+     * @param bool|null   $accessTokenExpired    Returns true if the access token has expired, if an expiration timestamp was available.
+     * @param string|null $refreshToken          A Refresh Token used by the user context. Null when unavailable.
+     */
+    public function fromIdToken(
+        array $profile,
+        ?string $idToken,
+        ?string $accessToken,
+        ?array $accessTokenScope,
+        ?int $accessTokenExpiration,
+        ?bool $accessTokenExpired,
+        ?string $refreshToken
+    ): \Illuminate\Contracts\Auth\Authenticatable;
+}

--- a/src/Contract/Auth0.php
+++ b/src/Contract/Auth0.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract;
+
+interface Auth0
+{
+    /**
+     * Create/return instance of the Auth0-PHP SDK.
+     */
+    public function getSdk(): \Auth0\SDK\Auth0;
+
+    /**
+     * Create/return instance of the Auth0-PHP SDK.
+     */
+    public function setSdk(
+        \Auth0\SDK\Auth0 $sdk
+    ): self;
+
+    /**
+     * Create/return instance of the Auth0-PHP SdkConfiguration.
+     */
+    public function getConfiguration(): \Auth0\SDK\Configuration\SdkConfiguration;
+
+    /**
+     * Assign the Auth0-PHP SdkConfiguration.
+     */
+    public function setConfiguration(
+        \Auth0\SDK\Configuration\SdkConfiguration $configuration
+    ): self;
+
+    /**
+     * Create/create a request state instance, a storage singleton containing authenticated user data.
+     */
+    public function getState(): \Auth0\Laravel\StateInstance;
+}

--- a/src/Contract/Event/Auth0Event.php
+++ b/src/Contract/Event/Auth0Event.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Event;
+
+interface Auth0Event
+{
+    /**
+     * Returns whether an event payload has been overwritten.
+     */
+    public function wasMutated(): bool;
+}

--- a/src/Contract/Event/Stateful/AuthenticationFailed.php
+++ b/src/Contract/Event/Stateful/AuthenticationFailed.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Event\Stateful;
+
+interface AuthenticationFailed
+{
+    /**
+     * AuthenticationFailed constructor.
+     *
+     * @param \Throwable $exception      An exception instance in which to throw for the authentication failure.
+     * @param bool       $throwException Whether or not $exception will be thrown.
+     */
+    public function __construct(
+        \Throwable $exception,
+        bool $throwException = true
+    );
+
+    /**
+     * Overwrite the exception to be thrown.
+     *
+     * @param \Throwable $exception An exception instance in which to throw for the authentication failure.
+     */
+    public function setException(
+        \Throwable $exception
+    ): self;
+
+    /**
+     * Returns the exception to be thrown.
+     */
+    public function getException(): \Throwable;
+
+    /**
+     * Determine whether the provided exception will be thrown by the SDK.
+     *
+     * @param bool $throwException Whether or not $exception will be thrown.
+     */
+    public function setThrowException(
+        bool $throwException
+    ): self;
+
+    /**
+     * Returns whether the provided exception will be thrown by the SDK.
+     */
+    public function getThrowException(): bool;
+}

--- a/src/Contract/Event/Stateful/AuthenticationSucceeded.php
+++ b/src/Contract/Event/Stateful/AuthenticationSucceeded.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Event\Stateful;
+
+interface AuthenticationSucceeded
+{
+    /**
+     * AuthenticationSucceeded constructor.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user  An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     */
+    public function __construct(
+        \Illuminate\Contracts\Auth\Authenticatable $user
+    );
+
+    /**
+     * Overwrite the authenticated user.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     */
+    public function setUser(
+        \Illuminate\Contracts\Auth\Authenticatable $user
+    ): self;
+
+    /**
+     * Return the authenticated user.
+     */
+    public function getUser(): \Illuminate\Contracts\Auth\Authenticatable;
+}

--- a/src/Contract/Exception/Stateful/CallbackException.php
+++ b/src/Contract/Exception/Stateful/CallbackException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Exception\Stateful;
+
+interface CallbackException
+{
+    /**
+     * Thrown when an API exception is encountered in an underlying network request.
+     *
+     * @param string $error            The error message to return.
+     * @param string $errorDescription The error description to return.
+     */
+    public static function apiException(
+        string $error,
+        string $errorDescription
+    ): self;
+}

--- a/src/Contract/Http/Controller/Stateful/Callback.php
+++ b/src/Contract/Http/Controller/Stateful/Callback.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Http\Controller\Stateful;
+
+interface Callback
+{
+    /**
+     * Process the session for the end user after returning from authenticating with Auth0.
+     *
+     * @param \Illuminate\Http\Request $request The incoming request instance.
+     */
+    public function __invoke(
+        \Illuminate\Http\Request $request
+    ): \Illuminate\Http\RedirectResponse;
+}

--- a/src/Contract/Http/Controller/Stateful/Login.php
+++ b/src/Contract/Http/Controller/Stateful/Login.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Http\Controller\Stateful;
+
+interface Login
+{
+    /**
+     * Redirect to the configured Auth0 Universal Login Page if a session is not available.
+     * Otherwise, redirect to the "/" route.
+     *
+     * @param \Illuminate\Http\Request $request The incoming request instance.
+     */
+    public function __invoke(
+        \Illuminate\Http\Request $request
+    ): \Illuminate\Http\RedirectResponse;
+}

--- a/src/Contract/Http/Controller/Stateful/Logout.php
+++ b/src/Contract/Http/Controller/Stateful/Logout.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Http\Controller\Stateful;
+
+interface Logout
+{
+    /**
+     * Redirect to Auth0's logout endpoint if a session is available.
+     * Otherwise, redirect to the "/" route.
+     *
+     * @param \Illuminate\Http\Request $request The incoming request instance.
+     */
+    public function __invoke(
+        \Illuminate\Http\Request $request
+    ): \Illuminate\Http\RedirectResponse;
+}

--- a/src/Contract/Http/Middleware/Stateful/Authenticate.php
+++ b/src/Contract/Http/Middleware/Stateful/Authenticate.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Http\Middleware\Stateful;
+
+interface Authenticate
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     */
+    public function handle(
+        \Illuminate\Http\Request $request,
+        \Closure $next
+    );
+}

--- a/src/Contract/Http/Middleware/Stateful/AuthenticateOptional.php
+++ b/src/Contract/Http/Middleware/Stateful/AuthenticateOptional.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Http\Middleware\Stateful;
+
+interface AuthenticateOptional
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     */
+    public function handle(
+        \Illuminate\Http\Request $request,
+        \Closure $next
+    );
+}

--- a/src/Contract/Http/Middleware/Stateless/Authorize.php
+++ b/src/Contract/Http/Middleware/Stateless/Authorize.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Http\Middleware\Stateless;
+
+interface Authorize
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     */
+    public function handle(
+        \Illuminate\Http\Request $request,
+        \Closure $next
+    );
+}

--- a/src/Contract/Http/Middleware/Stateless/AuthorizeOptional.php
+++ b/src/Contract/Http/Middleware/Stateless/AuthorizeOptional.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Http\Middleware\Stateless;
+
+interface AuthorizeOptional
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     */
+    public function handle(
+        \Illuminate\Http\Request $request,
+        \Closure $next
+    );
+}

--- a/src/Contract/Model/Stateful/User.php
+++ b/src/Contract/Model/Stateful/User.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Model\Stateful;
+
+interface User
+{
+}

--- a/src/Contract/Model/Stateless/User.php
+++ b/src/Contract/Model/Stateless/User.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Model\Stateless;
+
+interface User
+{
+}

--- a/src/Contract/Model/User.php
+++ b/src/Contract/Model/User.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Model;
+
+interface User
+{
+    /**
+     * \Auth0\Laravel\Model\User constructor.
+     */
+    public function __construct(
+        array $profile,
+        ?string $idToken,
+        ?string $accessToken,
+        ?array $accessTokenScope,
+        ?int $accessTokenExpiration,
+        ?bool $accessTokenExpired,
+        ?string $refreshToken
+    );
+
+    /**
+     * Add a generic getter to get all the properties of the user.
+     *
+     * @return mixed|null Returns the related value, or null if not set.
+     */
+    public function __get(
+        string $name
+    );
+
+    /**
+     * Return a JSON-encoded representation of the user.
+     */
+    public function __toString(): string;
+
+    /**
+     * Get the unique identifier for the user.
+     *
+     * @return mixed
+     */
+    public function getAuthIdentifier();
+
+    /**
+     * Get the name of the unique identifier for the user.
+     *
+     * @return string
+     */
+    public function getAuthIdentifierName();
+
+    /**
+     * Get the password for the user.
+     *
+     * @return string
+     */
+    public function getAuthPassword(): string;
+
+    /**
+     * Get the token value for the "remember me" session.
+     */
+    public function getRememberToken(): string;
+
+    /**
+     * Set the token value for the "remember me" session.
+     *
+     * @param string $value
+     */
+    public function setRememberToken(
+        $value
+    ): void;
+
+    /**
+     * Get the column name for the "remember me" token.
+     */
+    public function getRememberTokenName(): string;
+
+    /**
+     * Return the profile data for the user context. Null when unavailable.
+     */
+    public function getProfile(): ?array;
+
+    /**
+     * Return the ID Token for the user context. Null when unavailable.
+     */
+    public function getIdToken(): ?string;
+
+    /**
+     * Return the Access Token for the user context. Null when unavailable.
+     */
+    public function getAccessToken(): ?string;
+
+    /**
+     * Return the Access Token's scope for the user context. Null when unavailable.
+     */
+    public function getAccessTokenScope(): ?array;
+
+    /**
+     * Return the Access Token's expiration (represented as a unix timestamp) for the user context. Null when unavailable.
+     */
+    public function getAccessTokenExpiration(): ?int;
+
+    /**
+     * Return true if the Access Token has expired for the user context. Null when unavailable.
+     */
+    public function getAccessTokenExpired(): ?bool;
+
+    /**
+     * Return the Refresh Token for the user context. Null when unavailable.
+     */
+    public function getRefreshToken(): ?string;
+}

--- a/src/Contract/ServiceProvider.php
+++ b/src/Contract/ServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract;
+
+interface ServiceProvider
+{
+    /**
+     * Configure package details for Laravel's consumption.
+     */
+    public function configurePackage(
+        \Spatie\LaravelPackageTools\Package $package
+    ): void;
+
+    /**
+     * Register application services.
+     */
+    public function registeringPackage(): void;
+
+    /**
+     * Register middleware and guard.
+     */
+    public function bootingPackage(): void;
+}

--- a/src/Contract/StateInstance.php
+++ b/src/Contract/StateInstance.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract;
+
+interface StateInstance
+{
+    /**
+     * Set the authenticated user context for the current request.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable|null $user An authenticated user context.
+     */
+    public function setUser(
+        ?\Illuminate\Contracts\Auth\Authenticatable $user
+    ): self;
+
+    /**
+     * Return the authenticated user context for the current request.
+     */
+    public function getUser(): ?\Illuminate\Contracts\Auth\Authenticatable;
+}

--- a/src/Event/Auth0Event.php
+++ b/src/Event/Auth0Event.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Event;
 
-abstract class Auth0Event
+/**
+ * @codeCoverageIgnore
+ */
+abstract class Auth0Event implements \Auth0\Laravel\Contract\Event\Auth0Event
 {
     /**
      * Tracks whether an event payload has been overwritten.

--- a/src/Event/Stateful/AuthenticationFailed.php
+++ b/src/Event/Stateful/AuthenticationFailed.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Event\Stateful;
 
-use Throwable;
-
-final class AuthenticationFailed extends \Auth0\Laravel\Event\Auth0Event
+final class AuthenticationFailed extends \Auth0\Laravel\Event\Auth0Event implements \Auth0\Laravel\Contract\Event\Stateful\AuthenticationFailed
 {
     /**
      * An exception instance in which to throw for the authentication failure.
@@ -19,10 +17,7 @@ final class AuthenticationFailed extends \Auth0\Laravel\Event\Auth0Event
     private bool $throwException = true;
 
     /**
-     * AuthenticationFailed constructor.
-     *
-     * @param Throwable $exception      An exception instance in which to throw for the authentication failure.
-     * @param bool      $throwException Whether or not $exception will be thrown.
+     * @inheritdoc
      */
     public function __construct(
         \Throwable $exception,
@@ -33,9 +28,7 @@ final class AuthenticationFailed extends \Auth0\Laravel\Event\Auth0Event
     }
 
     /**
-     * Overwrite the exception to be thrown.
-     *
-     * @param Throwable $exception An exception instance in which to throw for the authentication failure.
+     * @inheritdoc
      */
     public function setException(
         \Throwable $exception
@@ -46,7 +39,7 @@ final class AuthenticationFailed extends \Auth0\Laravel\Event\Auth0Event
     }
 
     /**
-     * Returns the exception to be thrown.
+     * @inheritdoc
      */
     public function getException(): \Throwable
     {
@@ -54,9 +47,7 @@ final class AuthenticationFailed extends \Auth0\Laravel\Event\Auth0Event
     }
 
     /**
-     * Determine whether the provided exception will be thrown by the SDK.
-     *
-     * @param bool $throwException Whether or not $exception will be thrown.
+     * @inheritdoc
      */
     public function setThrowException(
         bool $throwException
@@ -66,7 +57,7 @@ final class AuthenticationFailed extends \Auth0\Laravel\Event\Auth0Event
     }
 
     /**
-     * Returns whether the provided exception will be thrown by the SDK.
+     * @inheritdoc
      */
     public function getThrowException(): bool
     {

--- a/src/Event/Stateful/AuthenticationSucceeded.php
+++ b/src/Event/Stateful/AuthenticationSucceeded.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Event\Stateful;
 
-use Illuminate\Contracts\Auth\Authenticatable;
-
-final class AuthenticationSucceeded extends \Auth0\Laravel\Event\Auth0Event
+final class AuthenticationSucceeded extends \Auth0\Laravel\Event\Auth0Event implements \Auth0\Laravel\Contract\Event\Stateful\AuthenticationSucceeded
 {
     /**
      * An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
@@ -14,9 +12,7 @@ final class AuthenticationSucceeded extends \Auth0\Laravel\Event\Auth0Event
     private \Illuminate\Contracts\Auth\Authenticatable $user;
 
     /**
-     * AuthenticationSucceeded constructor.
-     *
-     * @param Authenticatable $user  An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     * @inheritdoc
      */
     public function __construct(
         \Illuminate\Contracts\Auth\Authenticatable $user
@@ -25,9 +21,7 @@ final class AuthenticationSucceeded extends \Auth0\Laravel\Event\Auth0Event
     }
 
     /**
-     * Overwrite the authenticated user.
-     *
-     * @param Authenticatable $user An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     * @inheritdoc
      */
     public function setUser(
         \Illuminate\Contracts\Auth\Authenticatable $user
@@ -38,7 +32,7 @@ final class AuthenticationSucceeded extends \Auth0\Laravel\Event\Auth0Event
     }
 
     /**
-     * Return the authenticated user.
+     * @inheritdoc
      */
     public function getUser(): \Illuminate\Contracts\Auth\Authenticatable
     {

--- a/src/Exception/Stateful/CallbackException.php
+++ b/src/Exception/Stateful/CallbackException.php
@@ -7,10 +7,13 @@ namespace Auth0\Laravel\Exception\Stateful;
 /**
  * @codeCoverageIgnore
  */
-final class CallbackException extends \Exception implements \Auth0\SDK\Exception\Auth0Exception
+final class CallbackException extends \Exception implements \Auth0\SDK\Exception\Auth0Exception, \Auth0\Laravel\Contract\Exception\Stateful\CallbackException
 {
     public const MSG_API_RESPONSE = '%s: %s';
 
+    /**
+     * @inheritdoc
+     */
     public static function apiException(
         string $error,
         string $errorDescription

--- a/src/Http/Controller/Stateful/Callback.php
+++ b/src/Http/Controller/Stateful/Callback.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Http\Controller\Stateful;
 
-final class Callback
+final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful\Callback
 {
     /**
-     * Process the session for the end user after returning from authenticating with Auth0.
-     *
-     * @param \Illuminate\Http\Request $request The incoming request instance.
+     * @inheritdoc
      */
     public function __invoke(
         \Illuminate\Http\Request $request

--- a/src/Http/Controller/Stateful/Login.php
+++ b/src/Http/Controller/Stateful/Login.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Http\Controller\Stateful;
 
-final class Login
+final class Login implements \Auth0\Laravel\Contract\Http\Controller\Stateful\Login
 {
     /**
-     * Redirect to the configured Auth0 Universal Login Page if a session is not available.
-     * Otherwise, redirect to the "/" route.
-     *
-     * @param \Illuminate\Http\Request $request The incoming request instance.
+     * @inheritdoc
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */

--- a/src/Http/Controller/Stateful/Logout.php
+++ b/src/Http/Controller/Stateful/Logout.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Http\Controller\Stateful;
 
-final class Logout
+final class Logout implements \Auth0\Laravel\Contract\Http\Controller\Stateful\Logout
 {
     /**
-     * Redirect to Auth0's logout endpoint if a session is available.
-     * Otherwise, redirect to the "/" route.
-     *
-     * @param \Illuminate\Http\Request $request The incoming request instance.
+     * @inheritdoc
      */
     public function __invoke(
         \Illuminate\Http\Request $request

--- a/src/Http/Middleware/Stateful/Authenticate.php
+++ b/src/Http/Middleware/Stateful/Authenticate.php
@@ -11,15 +11,10 @@ namespace Auth0\Laravel\Http\Middleware\Stateful;
  *
  * @package Auth0\Laravel\Http\Middleware
  */
-final class Authenticate
+final class Authenticate implements \Auth0\Laravel\Contract\Http\Middleware\Stateful\Authenticate
 {
     /**
-     * Handle an incoming request.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure                 $next
-     *
-     * @return mixed
+     * @inheritdoc
      */
     public function handle(
         \Illuminate\Http\Request $request,

--- a/src/Http/Middleware/Stateful/AuthenticateOptional.php
+++ b/src/Http/Middleware/Stateful/AuthenticateOptional.php
@@ -11,15 +11,10 @@ namespace Auth0\Laravel\Http\Middleware\Stateful;
  *
  * @package Auth0\Laravel\Http\Middleware
  */
-final class AuthenticateOptional
+final class AuthenticateOptional implements \Auth0\Laravel\Contract\Http\Middleware\Stateful\AuthenticateOptional
 {
     /**
-     * Handle an incoming request.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure                 $next
-     *
-     * @return mixed
+     * @inheritdoc
      */
     public function handle(
         \Illuminate\Http\Request $request,

--- a/src/Http/Middleware/Stateless/Authorize.php
+++ b/src/Http/Middleware/Stateless/Authorize.php
@@ -10,15 +10,10 @@ namespace Auth0\Laravel\Http\Middleware\Stateless;
  *
  * @package Auth0\Laravel\Http\Middleware
  */
-final class Authorize
+final class Authorize implements \Auth0\Laravel\Contract\Http\Middleware\Stateless\Authorize
 {
     /**
-     * Handle an incoming request.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure                 $next
-     *
-     * @return mixed
+     * @inheritdoc
      */
     public function handle(
         \Illuminate\Http\Request $request,

--- a/src/Http/Middleware/Stateless/AuthorizeOptional.php
+++ b/src/Http/Middleware/Stateless/AuthorizeOptional.php
@@ -9,15 +9,10 @@ namespace Auth0\Laravel\Http\Middleware\Stateless;
  *
  * @package Auth0\Laravel\Http\Middleware
  */
-final class AuthorizeOptional
+final class AuthorizeOptional implements \Auth0\Laravel\Contract\Http\Middleware\Stateless\AuthorizeOptional
 {
     /**
-     * Handle an incoming request.
-     *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure                 $next
-     *
-     * @return mixed
+     * @inheritdoc
      */
     public function handle(
         \Illuminate\Http\Request $request,

--- a/src/Model/Stateful/User.php
+++ b/src/Model/Stateful/User.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Model\Stateful;
 
-final class User extends \Auth0\Laravel\Model\User
+final class User extends \Auth0\Laravel\Model\User implements \Auth0\Laravel\Contract\Model\Stateful\User
 {
 }

--- a/src/Model/Stateless/User.php
+++ b/src/Model/Stateless/User.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Model\Stateless;
 
-final class User extends \Auth0\Laravel\Model\User
+final class User extends \Auth0\Laravel\Model\User implements \Auth0\Laravel\Contract\Model\Stateless\User
 {
 }

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Model;
 
-abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
+abstract class User implements \Illuminate\Contracts\Auth\Authenticatable, \Auth0\Laravel\Contract\Model\User
 {
     /**
      * Profile data for the user context, when available.
@@ -42,7 +42,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     private ?string $refreshToken;
 
     /**
-     * \Auth0\Laravel\Model\User constructor.
+     * @inheritdoc
      */
     public function __construct(
         array $profile,
@@ -63,9 +63,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Add a generic getter to get all the properties of the user.
-     *
-     * @return mixed|null Returns the related value, or null if not set.
+     * @inheritdoc
      */
     public function __get(
         string $name
@@ -74,7 +72,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Return a JSON-encoded representation of the user.
+     * @inheritdoc
      */
     public function __toString(): string
     {
@@ -82,9 +80,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Get the unique identifier for the user.
-     *
-     * @return mixed
+     * @inheritdoc
      */
     public function getAuthIdentifier()
     {
@@ -96,9 +92,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Get the name of the unique identifier for the user.
-     *
-     * @return string
+     * @inheritdoc
      */
     public function getAuthIdentifierName()
     {
@@ -106,9 +100,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Get the password for the user.
-     *
-     * @return string
+     * @inheritdoc
      */
     public function getAuthPassword(): string
     {
@@ -116,7 +108,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Get the token value for the "remember me" session.
+     * @inheritdoc
      */
     public function getRememberToken(): string
     {
@@ -124,9 +116,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Set the token value for the "remember me" session.
-     *
-     * @param string $value
+     * @inheritdoc
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */
@@ -136,7 +126,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Get the column name for the "remember me" token.
+     * @inheritdoc
      */
     public function getRememberTokenName(): string
     {
@@ -144,7 +134,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Return the profile data for the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function getProfile(): ?array
     {
@@ -152,7 +142,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Return the ID Token for the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function getIdToken(): ?string
     {
@@ -160,7 +150,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Return the Access Token for the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function getAccessToken(): ?string
     {
@@ -168,7 +158,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Return the Access Token's scope for the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function getAccessTokenScope(): ?array
     {
@@ -176,7 +166,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Return the Access Token's expiration (represented as a unix timestamp) for the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function getAccessTokenExpiration(): ?int
     {
@@ -184,7 +174,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Return true if the Access Token has expired for the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function getAccessTokenExpired(): ?bool
     {
@@ -192,7 +182,7 @@ abstract class User implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Return the Refresh Token for the user context. Null when unavailable.
+     * @inheritdoc
      */
     public function getRefreshToken(): ?string
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel;
 
-final class ServiceProvider extends \Spatie\LaravelPackageTools\PackageServiceProvider
+final class ServiceProvider extends \Spatie\LaravelPackageTools\PackageServiceProvider implements \Auth0\Laravel\Contract\ServiceProvider
 {
+    /**
+     * @inheritdoc
+     */
     public function configurePackage(
         \Spatie\LaravelPackageTools\Package $package
     ): void {
@@ -15,7 +18,7 @@ final class ServiceProvider extends \Spatie\LaravelPackageTools\PackageServicePr
     }
 
     /**
-     * Register application services.
+     * @inheritdoc
      */
     public function registeringPackage(): void
     {
@@ -37,7 +40,7 @@ final class ServiceProvider extends \Spatie\LaravelPackageTools\PackageServicePr
     }
 
     /**
-     * Register middleware and guard.
+     * @inheritdoc
      */
     public function bootingPackage(): void
     {

--- a/src/StateInstance.php
+++ b/src/StateInstance.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel;
 
-use Illuminate\Contracts\Auth\Authenticatable;
-
 final class StateInstance
 {
     /**
@@ -14,9 +12,7 @@ final class StateInstance
     private ?\Illuminate\Contracts\Auth\Authenticatable $user = null;
 
     /**
-     * Set the authenticated user context for the current request.
-     *
-     * @param Authenticatable|null $user An authenticated user context.
+     * @inheritdoc
      */
     public function setUser(
         ?\Illuminate\Contracts\Auth\Authenticatable $user
@@ -26,7 +22,7 @@ final class StateInstance
     }
 
     /**
-     * Return the authenticated user context for the current request.
+     * @inheritdoc
      */
     public function getUser(): ?\Illuminate\Contracts\Auth\Authenticatable
     {

--- a/src/facade/Auth0.php
+++ b/src/facade/Auth0.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Facade;
 
+/**
+ * @codeCoverageIgnore
+ */
 final class Auth0 extends \Illuminate\Support\Facades\Facade
 {
     /**


### PR DESCRIPTION
This PR adds Interfaces to allow for class mocking within customer/downstream unit tests. This is necessary as we use the `final` keyword on classes to disallow extending/manipulating library methods, for reliability and safety best practices purposes.

The size of this PR is partly due to docblock changes, transitioning those documentation blocks from the classes and into their interfaces.