### PR TITLE
Automatically handle refreshing tokens when a token expires

### DIFF
--- a/config/auth0.php
+++ b/config/auth0.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+/**
+ * Please review available configuration options here:
+ * https://github.com/auth0/auth0-PHP#configuration-options
+ */
 return [
     // Should be assigned either 'api', 'management', or 'webapp' to indicate your application's use case for the SDK. Determines what configuration options will be required at initialization.
     'strategy' => env('AUTH0_STRATEGY', 'api'),
@@ -23,6 +27,9 @@ return [
 
     // One or more API identifiers, found in your Auth0 API settings. The SDK uses the first value for building links. If provided, at least one of these values must match the 'aud' claim to validate an ID Token successfully.
     'audience' => env('AUTH0_AUDIENCE', []),
+
+    // One or more scopes to request for Tokens. See https://auth0.com/docs/scopes
+    'scope' => explode(' ', env('AUTH0_SCOPE', 'openid profile email')),
 
     // One or more Organization IDs, found in your Auth0 Organization settings. The SDK uses the first value for building links. If provided, at least one of these values must match the 'org_id' claim to validate an ID Token successfully.
     'organization' => env('AUTH0_ORGANIZATION', []),

--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -130,11 +130,10 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard, \Auth0\Laravel\Co
      */
     public function hasScope(
         string $scope
-    ): bool
-    {
+    ): bool {
         $user = $this->getInstance()->getUser();
 
-        if ($user !== null && in_array($scope, $user->getAccessTokenScope())) {
+        if ($user !== null && in_array($scope, $user->getAccessTokenScope(), true)) {
             return true;
         }
 
@@ -261,7 +260,7 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard, \Auth0\Laravel\Co
             $refreshed = $this->getUserFromSession();
 
             // Was refreshed successfully?
-            if ($refreshed->getAccessTokenExpired() === false) {
+            if ($refreshed !== null && $refreshed->getAccessTokenExpired() === false) {
                 // Inform the host application to enable custom handling behavior
                 $event = new \Auth0\Laravel\Event\Stateful\TokenRefreshSucceeded($refreshed);
                 event($event);

--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -126,6 +126,22 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard, \Auth0\Laravel\Co
     }
 
     /**
+     * @inheritdoc
+     */
+    public function hasScope(
+        string $scope
+    ): bool
+    {
+        $user = $this->getInstance()->getUser();
+
+        if ($user !== null && in_array($scope, $user->getAccessTokenScope())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      *  @inheritdoc
      */
     public function setUser(
@@ -151,22 +167,16 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard, \Auth0\Laravel\Co
     public function user(): ?\Illuminate\Contracts\Auth\Authenticatable
     {
         $instance = $this->getInstance();
-        $user = $instance->getUser();
+        $user = null;
+        $token = $this->getTokenForRequest();
 
-        if ($user === null) {
-            $stateful = app('auth0')->getSdk()->getCredentials();
-
-            if ($stateful !== null) {
-                $user = $this->provider->retrieveByCredentials((array) $stateful);
-            }
+        if ($token !== null) {
+            $user = $this->provider->retrieveByToken([], $token);
         }
 
-        if ($user === null) {
-            $token = $this->getTokenForRequest();
-
-            if ($token !== null) {
-                $user = $this->provider->retrieveByToken([], $token);
-            }
+        if ($user === null && $token === null) {
+            $user = $this->getUserFromSession();
+            $user = $this->handleTokenExpiration($user);
         }
 
         if ($user !== null) {
@@ -208,5 +218,74 @@ final class Guard implements \Illuminate\Contracts\Auth\Guard, \Auth0\Laravel\Co
     private function getInstance(): \Auth0\Laravel\StateInstance
     {
         return app()->make(\Auth0\Laravel\StateInstance::class);
+    }
+
+    /**
+     * Get the local user session.
+     */
+    private function getUserFromSession(): ?\Illuminate\Contracts\Auth\Authenticatable
+    {
+        $session = app('auth0')->getSdk()->getCredentials();
+
+        if ($session !== null) {
+            return $this->provider->retrieveByCredentials((array) $session);
+        }
+
+        return null;
+    }
+
+    /**
+     * Handle instances of access token expiration.
+     */
+    private function handleTokenExpiration(
+        ?\Illuminate\Contracts\Auth\Authenticatable $user
+    ): ?\Illuminate\Contracts\Auth\Authenticatable {
+        if ($user === null) {
+            return null;
+        }
+
+        if ($user->getAccessTokenExpired() === false) {
+            return $user;
+        }
+
+        // Did we scope with 'offline_access' (and does the API allow) for a refresh token?
+        if ($user->getRefreshToken() !== null) {
+            try {
+                app('auth0')->getSdk()->renew();
+            } catch (\Auth0\SDK\Exception\StateException $tokenRefreshFailed) {
+                // Inform the host application token refresh failed, to enable custom handling behavior
+                event(new \Auth0\Laravel\Event\Stateful\TokenRefreshFailed());
+            }
+
+            // Retrieve any potentially updated state data
+            $refreshed = $this->getUserFromSession();
+
+            // Was refreshed successfully?
+            if ($refreshed->getAccessTokenExpired() === false) {
+                // Inform the host application to enable custom handling behavior
+                $event = new \Auth0\Laravel\Event\Stateful\TokenRefreshSucceeded($refreshed);
+                event($event);
+
+                return $event->getUser();
+            }
+        }
+
+        // We didn't have a refresh token, or the refresh failed. Inform host application.
+        $event = new \Auth0\Laravel\Event\Stateful\TokenExpired($user);
+        event($event);
+
+        // Did the host application override default expiration handling?
+        if ($event->getUser()->getAccessTokenExpired() === false) {
+            // Unless the host application expressly opted into not clearing the local user session, do so:
+            return $event->getUser();
+        }
+
+        if ($event->getClearSession() === true) {
+            // Clear the local user session:
+            $this->getInstance()->setUser(null);
+            app('auth0')->getSdk()->clear();
+        }
+
+        return null;
     }
 }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -83,7 +83,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     private function setSdkTelemetry(): self
     {
         \Auth0\SDK\Utility\HttpTelemetry::setEnvProperty('Laravel', app()->version());
-        \Auth0\SDK\Utility\HttpTelemetry::setPackage('laravel', self::SDK_VERSION);
+        \Auth0\SDK\Utility\HttpTelemetry::setPackage('laravel-auth0', self::SDK_VERSION);
 
         return $this;
     }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -12,7 +12,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     /**
      * The Laravel-Auth0 SDK version:
      */
-    public const SDK_VERSION = '7.0.0';
+    public const VERSION = '7.0.0';
 
     /**
      * An instance of the Auth0-PHP SDK.
@@ -84,7 +84,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     private function setSdkTelemetry(): self
     {
         \Auth0\SDK\Utility\HttpTelemetry::setEnvProperty('Laravel', app()->version());
-        \Auth0\SDK\Utility\HttpTelemetry::setPackage('laravel-auth0', self::SDK_VERSION);
+        \Auth0\SDK\Utility\HttpTelemetry::setPackage('laravel-auth0', self::VERSION);
 
         return $this;
     }

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -30,7 +30,8 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     public function getSdk(): \Auth0\SDK\Auth0
     {
         if ($this->sdk === null) {
-            $this->setSdk(new \Auth0\SDK\Auth0($this->getConfiguration()));
+            $this->sdk = new \Auth0\SDK\Auth0($this->getConfiguration());
+            $this->setSdkTelemetry();
         }
 
         return $this->sdk;

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -30,7 +30,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     public function getSdk(): \Auth0\SDK\Auth0
     {
         if ($this->sdk === null) {
-            $this->sdk = new \Auth0\SDK\Auth0($this->getConfiguration());
+            $this->setSdk(new \Auth0\SDK\Auth0($this->getConfiguration()));
         }
 
         return $this->sdk;
@@ -43,6 +43,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
         \Auth0\SDK\Auth0 $sdk
     ): self {
         $this->sdk = $sdk;
+        $this->setSdkTelemetry();
         return $this;
     }
 
@@ -74,5 +75,16 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     public function getState(): \Auth0\Laravel\StateInstance
     {
         return app()->make(\Auth0\Laravel\StateInstance::class);
+    }
+
+    /**
+     * Updates the Auth0 PHP SDK's telemetry to include the correct Laravel markers.
+     */
+    private function setSdkTelemetry(): self
+    {
+        \Auth0\SDK\Utility\HttpTelemetry::setEnvProperty('Laravel', app()->version());
+        \Auth0\SDK\Utility\HttpTelemetry::setPackage('laravel', self::SDK_VERSION);
+
+        return $this;
     }
 }

--- a/src/Contract/Event/Stateful/TokenExpired.php
+++ b/src/Contract/Event/Stateful/TokenExpired.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Event\Stateful;
+
+interface TokenExpired
+{
+    /**
+     * AuthenticationFailed constructor.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user         An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     * @param bool                                       $clearSession Whether or not the local user session will be cleared after the event resolves.
+     */
+    public function __construct(
+        \Illuminate\Contracts\Auth\Authenticatable $user,
+        bool $clearSession = true
+    );
+
+    /**
+     * Return the object representing the user session that has expired.
+     */
+    public function getUser(): \Illuminate\Contracts\Auth\Authenticatable;
+
+    /**
+     * Determine whether the provided exception will be thrown by the SDK.
+     *
+     * @param bool $clearException Whether or not the local user session will be cleared after the event resolves.
+     */
+    public function setClearSession(
+        bool $clearException
+    ): self;
+
+    /**
+     * Returns whether the SDK should clear the local user session after the event resolves.
+     */
+    public function getClearSession(): bool;
+}

--- a/src/Contract/Event/Stateful/TokenRefreshFailed.php
+++ b/src/Contract/Event/Stateful/TokenRefreshFailed.php
@@ -6,5 +6,4 @@ namespace Auth0\Laravel\Contract\Event\Stateful;
 
 interface TokenRefreshFailed
 {
-
 }

--- a/src/Contract/Event/Stateful/TokenRefreshFailed.php
+++ b/src/Contract/Event/Stateful/TokenRefreshFailed.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Event\Stateful;
+
+interface TokenRefreshFailed
+{
+
+}

--- a/src/Contract/Event/Stateful/TokenRefreshSucceeded.php
+++ b/src/Contract/Event/Stateful/TokenRefreshSucceeded.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract\Event\Stateful;
+
+interface TokenRefreshSucceeded
+{
+    /**
+     * TokenRefreshSucceeded constructor.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user  An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     */
+    public function __construct(
+        \Illuminate\Contracts\Auth\Authenticatable $user
+    );
+
+    /**
+     * Overwrite the authenticated user.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     */
+    public function setUser(
+        \Illuminate\Contracts\Auth\Authenticatable $user
+    ): self;
+
+    /**
+     * Return the authenticated user.
+     */
+    public function getUser(): \Illuminate\Contracts\Auth\Authenticatable;
+}

--- a/src/Contract/Http/Middleware/Stateless/Authorize.php
+++ b/src/Contract/Http/Middleware/Stateless/Authorize.php
@@ -11,11 +11,13 @@ interface Authorize
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
+     * @param string                   $scope
      *
      * @return mixed
      */
     public function handle(
         \Illuminate\Http\Request $request,
-        \Closure $next
+        \Closure $next,
+        string $scope
     );
 }

--- a/src/Event/Stateful/TokenExpired.php
+++ b/src/Event/Stateful/TokenExpired.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Event\Stateful;
+
+final class TokenExpired extends \Auth0\Laravel\Event\Auth0Event implements \Auth0\Laravel\Contract\Event\Stateful\TokenExpired
+{
+    /**
+     * An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     */
+    private \Illuminate\Contracts\Auth\Authenticatable $user;
+
+    /**
+     * Determines whether the local session will be cleared by the SDK after the event resolves.
+     */
+    private bool $clearSession;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct(
+        \Illuminate\Contracts\Auth\Authenticatable $user,
+        bool $clearSession = true
+    ) {
+        $this->user = $user;
+        $this->clearSession = $clearSession;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUser(): \Illuminate\Contracts\Auth\Authenticatable
+    {
+        return $this->user;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setClearSession(
+        bool $clearSession
+    ): self {
+        $this->clearSession = $clearSession;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getClearSession(): bool
+    {
+        return $this->clearSession;
+    }
+}

--- a/src/Event/Stateful/TokenRefreshFailed.php
+++ b/src/Event/Stateful/TokenRefreshFailed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Event\Stateful;
+
+final class TokenRefreshFailed extends \Auth0\Laravel\Event\Auth0Event implements \Auth0\Laravel\Contract\Event\Stateful\TokenRefreshFailed
+{
+}

--- a/src/Event/Stateful/TokenRefreshSucceeded.php
+++ b/src/Event/Stateful/TokenRefreshSucceeded.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Event\Stateful;
+
+final class TokenRefreshSucceeded extends \Auth0\Laravel\Event\Auth0Event implements \Auth0\Laravel\Contract\Event\Stateful\TokenRefreshSucceeded
+{
+    /**
+     * An instance of \Illuminate\Contracts\Auth\Authenticatable representing the authenticated user.
+     */
+    private \Illuminate\Contracts\Auth\Authenticatable $user;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct(
+        \Illuminate\Contracts\Auth\Authenticatable $user
+    ) {
+        $this->user = $user;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setUser(
+        \Illuminate\Contracts\Auth\Authenticatable $user
+    ): self {
+        $this->user = $user;
+        $this->mutated = true;
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getUser(): \Illuminate\Contracts\Auth\Authenticatable
+    {
+        return $this->user;
+    }
+}

--- a/src/Http/Middleware/Stateful/Authenticate.php
+++ b/src/Http/Middleware/Stateful/Authenticate.php
@@ -20,8 +20,10 @@ final class Authenticate implements \Auth0\Laravel\Contract\Http\Middleware\Stat
         \Illuminate\Http\Request $request,
         \Closure $next
     ) {
-        if (auth()->guard('auth0')->check()) {
-            auth()->guard('auth0')->login(auth()->guard('auth0')->user());
+        $user = auth()->guard('auth0')->user();
+
+        if ($user !== null && $user instanceof \Auth0\Laravel\Model\Stateful\User) {
+            auth()->guard('auth0')->login($user);
             return $next($request);
         }
 

--- a/src/Http/Middleware/Stateful/AuthenticateOptional.php
+++ b/src/Http/Middleware/Stateful/AuthenticateOptional.php
@@ -20,8 +20,10 @@ final class AuthenticateOptional implements \Auth0\Laravel\Contract\Http\Middlew
         \Illuminate\Http\Request $request,
         \Closure $next
     ) {
-        if (auth()->guard('auth0')->check()) {
-            auth()->guard('auth0')->login(auth()->guard('auth0')->user());
+        $user = auth()->guard('auth0')->user();
+
+        if ($user !== null && $user instanceof \Auth0\Laravel\Model\Stateful\User) {
+            auth()->guard('auth0')->login($user);
         }
 
         return $next($request);

--- a/src/Http/Middleware/Stateless/Authorize.php
+++ b/src/Http/Middleware/Stateless/Authorize.php
@@ -17,10 +17,17 @@ final class Authorize implements \Auth0\Laravel\Contract\Http\Middleware\Statele
      */
     public function handle(
         \Illuminate\Http\Request $request,
-        \Closure $next
+        \Closure $next,
+        string $scope = ''
     ) {
-        if (auth()->guard('auth0')->check()) {
-            auth()->login(auth()->guard('auth0')->user());
+        $user = auth()->guard('auth0')->user();
+
+        if ($user !== null && $user instanceof \Auth0\Laravel\Model\Stateless\User) {
+            if (strlen($scope) >= 1 && auth()->guard('auth0')->hasScope($scope) === false) {
+                return abort(403, 'Unauthorized');
+            }
+
+            auth()->login($user);
             return $next($request);
         }
 

--- a/src/Http/Middleware/Stateless/AuthorizeOptional.php
+++ b/src/Http/Middleware/Stateless/AuthorizeOptional.php
@@ -18,8 +18,10 @@ final class AuthorizeOptional implements \Auth0\Laravel\Contract\Http\Middleware
         \Illuminate\Http\Request $request,
         \Closure $next
     ) {
-        if (auth()->guard('auth0')->check()) {
-            auth()->guard('auth0')->login(auth()->guard('auth0')->user());
+        $user = auth()->guard('auth0')->user();
+
+        if ($user !== null && $user instanceof \Auth0\Laravel\Model\Stateless\User) {
+            auth()->guard('auth0')->login($user);
         }
 
         return $next($request);

--- a/src/Model/Stateful/User.php
+++ b/src/Model/Stateful/User.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Model\Stateful;
 
+/**
+ * This model class represents a user authenticated by an Auth0 PHP session.
+ */
 final class User extends \Auth0\Laravel\Model\User implements \Auth0\Laravel\Contract\Model\Stateful\User
 {
 }

--- a/src/Model/Stateless/User.php
+++ b/src/Model/Stateless/User.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Model\Stateless;
 
+/**
+ * This model class represents a user authorized by a bearer token.
+ */
 final class User extends \Auth0\Laravel\Model\User implements \Auth0\Laravel\Contract\Model\Stateless\User
 {
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -53,10 +53,9 @@ final class ServiceProvider extends \Spatie\LaravelPackageTools\PackageServicePr
         });
 
         $router = app()->make(\Illuminate\Routing\Router::class);
-        $router->aliasMiddleware('auth0.authenticate',  \Auth0\Laravel\Http\Middleware\Stateful\Authenticate::class);
-        $router->aliasMiddleware('auth0.authenticate.optional',  \Auth0\Laravel\Http\Middleware\Stateful\AuthenticateOptional::class);
-        $router->aliasMiddleware('auth0.authorize',  \Auth0\Laravel\Http\Middleware\Stateless\Authorize::class);
-        $router->aliasMiddleware('auth0.authorize.optional',  \Auth0\Laravel\Http\Middleware\Stateless\AuthorizeOptional::class);
-        $router->aliasMiddleware('auth0.authorize.scope',  \Auth0\Laravel\Http\Middleware\Stateless\AuthorizeScope::class);
+        $router->aliasMiddleware('auth0.authenticate', \Auth0\Laravel\Http\Middleware\Stateful\Authenticate::class);
+        $router->aliasMiddleware('auth0.authenticate.optional', \Auth0\Laravel\Http\Middleware\Stateful\AuthenticateOptional::class);
+        $router->aliasMiddleware('auth0.authorize', \Auth0\Laravel\Http\Middleware\Stateless\Authorize::class);
+        $router->aliasMiddleware('auth0.authorize.optional', \Auth0\Laravel\Http\Middleware\Stateless\AuthorizeOptional::class);
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -51,5 +51,12 @@ final class ServiceProvider extends \Spatie\LaravelPackageTools\PackageServicePr
         auth()->extend('auth0', static function ($app, $name, array $config): \Auth0\Laravel\Auth\Guard {
             return new \Auth0\Laravel\Auth\Guard(auth()->createUserProvider($config['provider']), $app->make('request'));
         });
+
+        $router = app()->make(\Illuminate\Routing\Router::class);
+        $router->aliasMiddleware('auth0.authenticate',  \Auth0\Laravel\Http\Middleware\Stateful\Authenticate::class);
+        $router->aliasMiddleware('auth0.authenticate.optional',  \Auth0\Laravel\Http\Middleware\Stateful\AuthenticateOptional::class);
+        $router->aliasMiddleware('auth0.authorize',  \Auth0\Laravel\Http\Middleware\Stateless\Authorize::class);
+        $router->aliasMiddleware('auth0.authorize.optional',  \Auth0\Laravel\Http\Middleware\Stateless\AuthorizeOptional::class);
+        $router->aliasMiddleware('auth0.authorize.scope',  \Auth0\Laravel\Http\Middleware\Stateless\AuthorizeScope::class);
     }
 }


### PR DESCRIPTION
This PR adds support for automatically refreshing stateful user sessions when configured with an `offiline_access` scope and a refresh token is present, allowing for extended sessions.

Three other minor adjustments contained that these changes rely on to successfully pass tests:
- The library now self-registers it's router middleware controllers, for less integration effort on the developer's end.
- Adds a 'hasScope' helper to check if a stateless or stateful request has a necessary scope.
- Fixes stateless requests not properly keeping track of the `exp` claim on a access token in the user object.
- Restores `laravel-auth0` telemetry header in API network requests

(This relies on a bugfix in the upstream PHP SDK with a pending release of 8.0.6 to fix a refresh token issue.)