### PR TITLE
Finalize configuration file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor/
 composer.lock
 composer.phar
 .phpunit.result.cache
+composer.local.json

--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
     "spatie/laravel-package-tools": "^1.9"
   },
   "require-dev": {
-    "laravel/laravel": "^8.4.4 || ^9.0",
     "ergebnis/phpstan-rules": "^1.0",
+    "laravel/laravel": "^8.4.4 || ^9.0",
     "nunomaduro/larastan": "^1.0",
     "nunomaduro/phpinsights": "^2.0",
     "nyholm/psr7": "^1.4",
@@ -51,7 +51,8 @@
     "pestphp/pest-plugin-laravel": "^1.2",
     "phpstan/phpstan-strict-rules": "^1.1",
     "phpunit/phpunit": "^9.5",
-    "thecodingmachine/phpstan-strict-rules": "^1.0"
+    "thecodingmachine/phpstan-strict-rules": "^1.0",
+    "wikimedia/composer-merge-plugin": "^2.0"
   },
   "autoload": {
     "psr-4": {
@@ -71,6 +72,18 @@
       "aliases": {
         "Auth0": "Auth0\\Laravel\\Facade\\Auth0"
       }
+    },
+    "merge-plugin": {
+      "include": [
+        "composer.local.json"
+      ],
+      "recurse": true,
+      "replace": true,
+      "ignore-duplicates": false,
+      "merge-dev": true,
+      "merge-extra": false,
+      "merge-extra-deep": false,
+      "merge-scripts": false
     }
   },
   "config": {

--- a/config/auth0.php
+++ b/config/auth0.php
@@ -7,8 +7,9 @@ declare(strict_types=1);
  * https://github.com/auth0/auth0-PHP#configuration-options
  */
 return [
-    // Should be assigned either 'api', 'management', or 'webapp' to indicate your application's use case for the SDK. Determines what configuration options will be required at initialization.
-    'strategy' => env('AUTH0_STRATEGY', 'api'),
+    // Should be assigned either 'api', 'management', or 'webapp' to indicate your application's use case for the SDK.
+    // Determines what configuration options will be required.
+    'strategy' => env('AUTH0_STRATEGY', 'webapp'),
 
     // Auth0 domain for your tenant, found in your Auth0 Application settings.
     'domain' => env('AUTH0_DOMAIN'),
@@ -26,13 +27,13 @@ return [
     'clientSecret' => env('AUTH0_CLIENT_SECRET'),
 
     // One or more API identifiers, found in your Auth0 API settings. The SDK uses the first value for building links. If provided, at least one of these values must match the 'aud' claim to validate an ID Token successfully.
-    'audience' => env('AUTH0_AUDIENCE', []),
+    'audience' => \Auth0\Laravel\Configuration::stringToArrayOrNull(env('AUTH0_AUDIENCE')),
 
     // One or more scopes to request for Tokens. See https://auth0.com/docs/scopes
-    'scope' => explode(' ', env('AUTH0_SCOPE', 'openid profile email')),
+    'scope' => \Auth0\Laravel\Configuration::stringToArrayOrNull(env('AUTH0_SCOPE')),
 
     // One or more Organization IDs, found in your Auth0 Organization settings. The SDK uses the first value for building links. If provided, at least one of these values must match the 'org_id' claim to validate an ID Token successfully.
-    'organization' => env('AUTH0_ORGANIZATION', []),
+    'organization' => \Auth0\Laravel\Configuration::stringToArrayOrNull(env('AUTH0_ORGANIZATION')),
 
     // The secret used to derive an encryption key for the user identity in a session cookie and to sign the transient cookies used by the login callback.
     'cookieSecret' => env('AUTH0_COOKIE_SECRET', env('APP_KEY')),
@@ -40,8 +41,20 @@ return [
     // How long, in seconds, before cookies expire. If set to 0 the cookie will expire at the end of the session (when the browser closes).
     'cookieExpires' => env('COOKIE_EXPIRES', 0),
 
-    // Named routes the SDK may call during stateful requests for redirections.
-    'routeLogin' => 'login',
-    'routeLogout' => 'logout',
-    'routeCallback' => 'callback',
+    // Cookie domain, for example 'www.example.com', for use with PHP sessions and SDK cookies. Defaults to value of HTTP_HOST server environment information.
+    // Note: To make cookies visible on all subdomains then the domain must be prefixed with a dot like '.example.com'.
+    'cookieDomain' => env('AUTH0_COOKIE_DOMAIN'),
+
+    // Specifies path on the domain where the cookies will work. Defaults to '/'. Use a single slash ('/') for all paths on the domain.
+    'cookiePath' => env('AUTH0_COOKIE_PATH'),
+
+    // Defaults to false. Specifies whether cookies should ONLY be sent over secure connections.
+    'cookieSecure' => \Auth0\Laravel\Configuration::stringToBoolOrNull(env('AUTH0_COOKIE_SECRET'), false),
+
+    // Named routes within your Laravel application that the SDK may call during stateful requests for redirections.
+    'routes' => [
+        'login' => env('AUTH0_ROUTE_LOGIN', 'login'),
+        'logout' => env('AUTH0_ROUTE_LOGOUT', 'logout'),
+        'callback' => env('AUTH0_ROUTE_CALLBACK', 'callback')
+    ]
 ];

--- a/config/auth0.php
+++ b/config/auth0.php
@@ -49,7 +49,7 @@ return [
     'cookiePath' => env('AUTH0_COOKIE_PATH'),
 
     // Defaults to false. Specifies whether cookies should ONLY be sent over secure connections.
-    'cookieSecure' => \Auth0\Laravel\Configuration::stringToBoolOrNull(env('AUTH0_COOKIE_SECRET'), false),
+    'cookieSecure' => \Auth0\Laravel\Configuration::stringToBoolOrNull(env('AUTH0_COOKIE_SECURE'), false),
 
     // Named routes within your Laravel application that the SDK may call during stateful requests for redirections.
     'routes' => [

--- a/config/auth0.php
+++ b/config/auth0.php
@@ -53,8 +53,7 @@ return [
 
     // Named routes within your Laravel application that the SDK may call during stateful requests for redirections.
     'routes' => [
-        'login' => env('AUTH0_ROUTE_LOGIN', 'login'),
-        'logout' => env('AUTH0_ROUTE_LOGOUT', 'logout'),
-        'callback' => env('AUTH0_ROUTE_CALLBACK', 'callback')
+        'home' => env('AUTH0_ROUTE_HOME', '/'),
+        'login' => env('AUTH0_ROUTE_LOGIN', 'login')
     ]
 ];

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel;
+
+/**
+ * Helpers to map configuration data stored as strings from .env files into formats consumable by the Auth0-PHP SDK.
+ */
+final class Configuration implements \Auth0\Laravel\Contract\Configuration
+{
+    /**
+     * @inheritdoc
+     */
+    public static function stringToArrayOrNull(
+        ?string $config,
+        string $delimiter = ' ',
+    ): ?array {
+        if (is_string($config) === true && strlen($config) >= 1 && strlen($delimiter) >= 1) {
+            $response = explode($delimiter, $config);
+
+            // @phpstan-ignore-next-line
+            if (is_array($response) === true && count($response) >= 1 && strlen(trim($response[0])) !== '') {
+                return $response;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function stringToBoolOrNull(
+        ?string $config,
+        ?bool $default = null
+    ): ?bool {
+        if (is_string($config) === true && strlen($config) >= 1) {
+            $config = strtolower(trim($config));
+
+            if ($config === 'true') {
+                return true;
+            }
+
+            return false;
+        }
+
+        return $default;
+    }
+}

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -38,11 +38,7 @@ final class Configuration implements \Auth0\Laravel\Contract\Configuration
         if (is_string($config) === true && strlen($config) >= 1) {
             $config = strtolower(trim($config));
 
-            if ($config === 'true') {
-                return true;
-            }
-
-            return false;
+            return $config === 'true';
         }
 
         return $default;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -14,7 +14,7 @@ final class Configuration implements \Auth0\Laravel\Contract\Configuration
      */
     public static function stringToArrayOrNull(
         ?string $config,
-        string $delimiter = ' ',
+        string $delimiter = ' '
     ): ?array {
         if (is_string($config) === true && strlen($config) >= 1 && strlen($delimiter) >= 1) {
             $response = explode($delimiter, $config);

--- a/src/Contract/Configuration.php
+++ b/src/Contract/Configuration.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Laravel\Contract;
+
+interface Configuration
+{
+    /**
+     * Converts a delimited string into an array, or null, if nothing was provided.
+     *
+     * @param string|null $config    The string contents to convert, i.e. 'one two three'.
+     * @param string      $delimiter The string delimiter to split the string contents with; defaults to space.
+     */
+    public static function stringToArrayOrNull(
+        ?string $config,
+        string $delimiter = ' ',
+    ): ?array;
+
+    /**
+     * Converts a truthy string representation into a boolean.
+     *
+     * @param string|null $config  The string contents to convert, i.e. 'true'
+     * @param bool|null   $default The default boolean value to return if a valid string wasn't provided.
+     */
+    public static function stringToBoolOrNull(
+        ?string $config,
+        ?bool $default = null
+    ): ?bool;
+}

--- a/src/Contract/Configuration.php
+++ b/src/Contract/Configuration.php
@@ -14,7 +14,7 @@ interface Configuration
      */
     public static function stringToArrayOrNull(
         ?string $config,
-        string $delimiter = ' ',
+        string $delimiter = ' '
     ): ?array;
 
     /**

--- a/src/Http/Controller/Stateful/Callback.php
+++ b/src/Http/Controller/Stateful/Callback.php
@@ -15,7 +15,7 @@ final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful
         // Check if the user already has a session:
         if (auth()->guard('auth0')->check()) {
             // They do; redirect to homepage.
-            return redirect()->intended('/');
+            return redirect()->intended(app()->make('config')->get('auth0.routes.home', '/'));
         }
 
         try {
@@ -70,6 +70,6 @@ final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful
             auth()->guard('auth0')->setUser($event->getUser());
         }
 
-        return redirect()->intended('/');
+        return redirect()->intended(app()->make('config')->get('auth0.routes.home', '/'));
     }
 }

--- a/src/Http/Controller/Stateful/Login.php
+++ b/src/Http/Controller/Stateful/Login.php
@@ -15,7 +15,7 @@ final class Login implements \Auth0\Laravel\Contract\Http\Controller\Stateful\Lo
         \Illuminate\Http\Request $request
     ): \Illuminate\Http\RedirectResponse {
         if (auth()->guard('auth0')->check()) {
-            return redirect()->intended('/');
+            return redirect()->intended(app()->make('config')->get('auth0.routes.home', '/'));
         }
 
         return redirect()->away(app('auth0')->getSdk()->login());

--- a/src/Http/Controller/Stateful/Logout.php
+++ b/src/Http/Controller/Stateful/Logout.php
@@ -21,6 +21,6 @@ final class Logout implements \Auth0\Laravel\Contract\Http\Controller\Stateful\L
             return redirect()->away(app('auth0')->getSdk()->authentication()->getLogoutLink());
         }
 
-        return redirect()->intended('/');
+        return redirect()->intended(app()->make('config')->get('auth0.routes.home', '/'));
     }
 }

--- a/src/Http/Middleware/Stateful/Authenticate.php
+++ b/src/Http/Middleware/Stateful/Authenticate.php
@@ -27,6 +27,6 @@ final class Authenticate implements \Auth0\Laravel\Contract\Http\Middleware\Stat
             return $next($request);
         }
 
-        return redirect('login');
+        return redirect(app()->make('config')->get('auth0.routes.login', 'login'));
     }
 }


### PR DESCRIPTION
This PR includes three small changes:

- It adds a `Auth0\Laravel\Configuration` class with helper static functions to map the string-based storage format of `.env` files into the property types the Auth0-PHP SDK requires at configuration time; for example a `true` string value into a boolean, and an a space-delimited string to scopes into an array of strings.
- It updates the `config/auth0.php` file to add several common configuration parameters, and updates the format to use the new `Auth0\Laravel\Configuration` class.
- It adds support for `composer.local.json` manifests, to simplify development of the package locally.