### PR TITLE
Update `Auth\User\Provider::__construct()` to accept a Repository Interface, rather than Class

### DIFF
--- a/src/Auth/User/Provider.php
+++ b/src/Auth/User/Provider.php
@@ -9,7 +9,7 @@ final class Provider implements \Illuminate\Contracts\Auth\UserProvider, \Auth0\
     /**
      * A repository instance.
      */
-    private Repository $repository;
+    private \Auth0\Laravel\Contract\Auth\User\Repository $repository;
 
     /**
      * @inheritdoc

--- a/src/Auth/User/Provider.php
+++ b/src/Auth/User/Provider.php
@@ -15,7 +15,7 @@ final class Provider implements \Illuminate\Contracts\Auth\UserProvider, \Auth0\
      * @inheritdoc
      */
     public function __construct(
-        \Auth0\Laravel\Auth\User\Repository $repository
+        \Auth0\Laravel\Contract\Auth\User\Repository $repository
     ) {
         $this->repository = $repository;
     }


### PR DESCRIPTION
This PR updates `Auth\User\Provider::__construct()` to accept the `Auth0\Laravel\Contract\Auth\User\Repository` interface contract type, rather than the `Auth0\Laravel\Auth\User\Repository` class type itself, to allow custom user providers to be assigned during app configuration.

Closes #256 