### PR TITLE
Allow post-logout return url to be configurable

### DIFF
--- a/src/Http/Controller/Stateful/Logout.php
+++ b/src/Http/Controller/Stateful/Logout.php
@@ -18,7 +18,7 @@ final class Logout implements \Auth0\Laravel\Contract\Http\Controller\Stateful\L
             $request->session()->invalidate();
             $request->session()->regenerateToken();
 
-            return redirect()->away(app('auth0')->getSdk()->authentication()->getLogoutLink());
+            return redirect()->away(app('auth0')->getSdk()->authentication()->getLogoutLink(url(app()->make('config')->get('auth0.routes.home', '/'))));
         }
 
         return redirect()->intended(app()->make('config')->get('auth0.routes.home', '/'));


### PR DESCRIPTION
This PR updates the logout HTTP Controller (`Auth0\Laravel\Http\Controller\Stateful\Logout`) to:
- Redirect the end user back to the host app's index route (`/`) by default, instead of the SDK's callback route
- Allow the return route/url to be configurable by the developer using the `auth0.routes.home` configuration path

Resolves #260