### PR TITLE
authenticate/authorize custom user models via interfaces in middleware

### DIFF
--- a/src/Http/Middleware/Stateful/Authenticate.php
+++ b/src/Http/Middleware/Stateful/Authenticate.php
@@ -22,7 +22,7 @@ final class Authenticate implements \Auth0\Laravel\Contract\Http\Middleware\Stat
     ) {
         $user = auth()->guard('auth0')->user();
 
-        if ($user !== null && $user instanceof \Auth0\Laravel\Model\Stateful\User) {
+        if ($user !== null && $user instanceof \Auth0\Laravel\Contract\Model\Stateful\User) {
             auth()->guard('auth0')->login($user);
             return $next($request);
         }

--- a/src/Http/Middleware/Stateful/AuthenticateOptional.php
+++ b/src/Http/Middleware/Stateful/AuthenticateOptional.php
@@ -22,7 +22,7 @@ final class AuthenticateOptional implements \Auth0\Laravel\Contract\Http\Middlew
     ) {
         $user = auth()->guard('auth0')->user();
 
-        if ($user !== null && $user instanceof \Auth0\Laravel\Model\Stateful\User) {
+        if ($user !== null && $user instanceof \Auth0\Laravel\Contract\Model\Stateful\User) {
             auth()->guard('auth0')->login($user);
         }
 

--- a/src/Http/Middleware/Stateless/Authorize.php
+++ b/src/Http/Middleware/Stateless/Authorize.php
@@ -22,7 +22,7 @@ final class Authorize implements \Auth0\Laravel\Contract\Http\Middleware\Statele
     ) {
         $user = auth()->guard('auth0')->user();
 
-        if ($user !== null && $user instanceof \Auth0\Laravel\Model\Stateless\User) {
+        if ($user !== null && $user instanceof \Auth0\Laravel\Contract\Model\Stateless\User) {
             if (strlen($scope) >= 1 && auth()->guard('auth0')->hasScope($scope) === false) {
                 return abort(403, 'Unauthorized');
             }

--- a/src/Http/Middleware/Stateless/AuthorizeOptional.php
+++ b/src/Http/Middleware/Stateless/AuthorizeOptional.php
@@ -20,7 +20,7 @@ final class AuthorizeOptional implements \Auth0\Laravel\Contract\Http\Middleware
     ) {
         $user = auth()->guard('auth0')->user();
 
-        if ($user !== null && $user instanceof \Auth0\Laravel\Model\Stateless\User) {
+        if ($user !== null && $user instanceof \Auth0\Laravel\Contract\Model\Stateless\User) {
             auth()->guard('auth0')->login($user);
         }
 


### PR DESCRIPTION
### Changes

This PR applies the Interfaces introduced in https://github.com/auth0/laravel-auth0/pull/248 and allows to authenticate/authorize custom User models with the provided middleware.

### References

Resolves  https://github.com/auth0/laravel-auth0/issues/256

### Testing

When using a custom UserModel from a custom UserRepository the provided middlewares won't throw 403 Unauthenticated because the user instance is tested against the interface.

