### PR TITLE
Add FOSSA license action to workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,8 +22,16 @@ jobs:
     name: FOSSA License Compliance
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
       - uses: actions/checkout@v3
-      - uses: fossas/fossa-action@main
+
+      - name: "Run FOSSA Scan"
+        uses: fossas/fossa-action@main
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}
+
+      - name: "Run FOSSA Test"
+        uses: fossas/fossa-action@main
         with:
           api-key: ${{secrets.FOSSA_API_KEY}}
           run-tests: true

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,3 +17,13 @@ jobs:
 
       - name: Composer normalize
         uses: docker://ergebnis/composer-normalize-action
+
+  fossa-scan:
+    name: FOSSA License Compliance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: fossas/fossa-action@main
+        with:
+          api-key: ${{secrets.FOSSA_API_KEY}}
+          run-tests: true


### PR DESCRIPTION
Closing as the GitHub Action for FOSSA is too limited. Relying on webhook method instead.