### PR TITLE
Remember what page the user was on,…

### DIFF
--- a/src/Http/Middleware/Stateful/Authenticate.php
+++ b/src/Http/Middleware/Stateful/Authenticate.php
@@ -27,6 +27,6 @@ final class Authenticate implements \Auth0\Laravel\Contract\Http\Middleware\Stat
             return $next($request);
         }
 
-        return redirect(app()->make('config')->get('auth0.routes.login', 'login'));
+        return redirect()->guest(app()->make('config')->get('auth0.routes.login', 'login'));
     }
 }


### PR DESCRIPTION
…,when redirecting to auth, bu using the guest method on the redirector

### Changes

- using the guest method on the redirector, so laravel set the intended url, so the callbacks redirects to the correct previus url.

### References

- Solves #283

### Testing

See issue #283

### Contributor Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
