### PR TITLE
fix: `errorDescription` value incorrectly assigned

### DIFF
--- a/src/Http/Controller/Stateful/Callback.php
+++ b/src/Http/Controller/Stateful/Callback.php
@@ -40,7 +40,7 @@ final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful
             $error = $request->query('error', '');
             $errorDescription = $request->query('error_description', '');
             $error = is_string($error) ? $error : '';
-            $errorDescription = is_string($errorDescription) ? $error : '';
+            $errorDescription = is_string($errorDescription) ? $errorDescription : '';
 
             // Clear the local session via the Auth0-PHP SDK:
             app('auth0')->getSdk()->clear();


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

This PR fixes a bug where `$errorDescription` is incorrectly assigned the value of `$error` instead of `$errorDescription` after an `is_string()` check on the variable type.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #287

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
