### PR TITLE
Add Ship CLI configuration

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,0 +1,6 @@
+{
+  "files": {
+    "src/Auth0.php": []
+  },
+  "prefixVersion": false
+}


### PR DESCRIPTION
This PR adds the configuration file for Auth0's Ship CLI, a CLI tool we use to automate the release preparation.

In this config we are:

- Configuring Ship CLI to replace the version located in `src/Auth0.php`
- Configuring Ship CLI to not prefix releases and tags with `v`.