### PR TITLE
change: Use class names for app() calls

### DIFF
--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -43,7 +43,7 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
     public function logout(): self
     {
         $this->getState()->setUser(null);
-        app('auth0')->getSdk()->clear();
+        app(\Auth0\Laravel\Auth0::class)->getSdk()->clear();
         return $this;
     }
 
@@ -148,7 +148,7 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
 
         try {
             // Attempt to decode the bearer token.
-            $decoded = app('auth0')->getSdk()->decode($token, null, null, null, null, null, null, \Auth0\SDK\Token::TYPE_TOKEN)->toArray();
+            $decoded = app(\Auth0\Laravel\Auth0::class)->getSdk()->decode($token, null, null, null, null, null, null, \Auth0\SDK\Token::TYPE_TOKEN)->toArray();
         } catch (\Auth0\SDK\Exception\InvalidTokenException $invalidToken) {
             // Invalid bearer token.
             return null;
@@ -184,7 +184,7 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
     private function getUserFromSession(): ?\Illuminate\Contracts\Auth\Authenticatable
     {
         // Retrieve an available session from the Auth0-PHP SDK.
-        $session = app('auth0')->getSdk()->getCredentials();
+        $session = app(\Auth0\Laravel\Auth0::class)->getSdk()->getCredentials();
 
         // If a session is not available, return null.
         if ($session === null) {
@@ -236,14 +236,14 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
         if ($state->getRefreshToken() !== null) {
             try {
                 // Try to renew our token.
-                app('auth0')->getSdk()->renew();
+                app(\Auth0\Laravel\Auth0::class)->getSdk()->renew();
             } catch (\Auth0\SDK\Exception\StateException $tokenRefreshFailed) {
                 // Renew failed. Inform application.
                 event(new \Auth0\Laravel\Event\Stateful\TokenRefreshFailed());
             }
 
             // Retrieve updated state data
-            $refreshed = app('auth0')->getSdk()->getCredentials();
+            $refreshed = app(\Auth0\Laravel\Auth0::class)->getSdk()->getCredentials();
 
             if ($refreshed !== null && $refreshed->accessTokenExpired === false) {
                 event(new \Auth0\Laravel\Event\Stateful\TokenRefreshSucceeded());
@@ -254,7 +254,7 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
         // We didn't have a refresh token, or the refresh failed.
         // Clear session.
         $state->clear();
-        app('auth0')->getSdk()->clear();
+        app(\Auth0\Laravel\Auth0::class)->getSdk()->clear();
 
         // Inform host application.
         event(new \Auth0\Laravel\Event\Stateful\TokenExpired());

--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -125,12 +125,7 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
         string $scope
     ): bool {
         $state = $this->getState();
-
-        if (in_array($scope, $state->getAccessTokenScope() ?? [], true)) {
-            return true;
-        }
-
-        return false;
+        return in_array($scope, $state->getAccessTokenScope() ?? [], true);
     }
 
     /**

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -16,11 +16,11 @@ final class Configuration implements \Auth0\Laravel\Contract\Configuration
         ?string $config,
         string $delimiter = ' '
     ): ?array {
-        if (is_string($config) === true && strlen($config) >= 1 && strlen($delimiter) >= 1) {
+        if (is_string($config) && strlen($config) >= 1 && strlen($delimiter) >= 1) {
             $response = explode($delimiter, $config);
 
             // @phpstan-ignore-next-line
-            if (is_array($response) === true && count($response) >= 1 && strlen(trim($response[0])) !== 0) {
+            if (is_array($response) && count($response) >= 1 && strlen(trim($response[0])) !== 0) {
                 return $response;
             }
         }
@@ -35,7 +35,7 @@ final class Configuration implements \Auth0\Laravel\Contract\Configuration
         ?string $config,
         ?bool $default = null
     ): ?bool {
-        if (is_string($config) === true && strlen($config) >= 1) {
+        if (is_string($config) && strlen($config) >= 1) {
             $config = strtolower(trim($config));
 
             return $config === 'true';

--- a/src/Http/Controller/Stateful/Callback.php
+++ b/src/Http/Controller/Stateful/Callback.php
@@ -30,7 +30,7 @@ final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful
             event($event);
 
             // If the event was not hooked by the host application, throw an exception:
-            if ($event->getThrowException() === true) {
+            if ($event->getThrowException()) {
                 throw $exception;
             }
         }
@@ -53,7 +53,7 @@ final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful
             event($event);
 
             // If the event was not hooked by the host application, throw an exception:
-            if ($event->getThrowException() === true) {
+            if ($event->getThrowException()) {
                 throw $exception;
             }
         }

--- a/src/Http/Controller/Stateful/Callback.php
+++ b/src/Http/Controller/Stateful/Callback.php
@@ -20,10 +20,10 @@ final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful
 
         try {
             if ($request->query('state') !== null && $request->query('code') !== null) {
-                app('auth0')->getSdk()->exchange();
+                app(\Auth0\Laravel\Auth0::class)->getSdk()->exchange();
             }
         } catch (\Throwable $exception) {
-            app('auth0')->getSdk()->clear();
+            app(\Auth0\Laravel\Auth0::class)->getSdk()->clear();
 
             // Throw hookable $event to allow custom error handling scenarios.
             $event = new \Auth0\Laravel\Event\Stateful\AuthenticationFailed($exception, true);
@@ -43,7 +43,7 @@ final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful
             $errorDescription = is_string($errorDescription) ? $errorDescription : '';
 
             // Clear the local session via the Auth0-PHP SDK:
-            app('auth0')->getSdk()->clear();
+            app(\Auth0\Laravel\Auth0::class)->getSdk()->clear();
 
             // Create a dynamic exception to report the API error response:
             $exception = \Auth0\Laravel\Exception\Stateful\CallbackException::apiException($error, $errorDescription);

--- a/src/Http/Controller/Stateful/Login.php
+++ b/src/Http/Controller/Stateful/Login.php
@@ -18,6 +18,6 @@ final class Login implements \Auth0\Laravel\Contract\Http\Controller\Stateful\Lo
             return redirect()->intended(app()->make('config')->get('auth0.routes.home', '/'));
         }
 
-        return redirect()->away(app('auth0')->getSdk()->login());
+        return redirect()->away(app(\Auth0\Laravel\Auth0::class)->getSdk()->login());
     }
 }

--- a/src/Http/Controller/Stateful/Logout.php
+++ b/src/Http/Controller/Stateful/Logout.php
@@ -18,7 +18,7 @@ final class Logout implements \Auth0\Laravel\Contract\Http\Controller\Stateful\L
             $request->session()->invalidate();
             $request->session()->regenerateToken();
 
-            return redirect()->away(app('auth0')->getSdk()->authentication()->getLogoutLink(url(app()->make('config')->get('auth0.routes.home', '/'))));
+            return redirect()->away(app(\Auth0\Laravel\Auth0::class)->getSdk()->authentication()->getLogoutLink(url(app()->make('config')->get('auth0.routes.home', '/'))));
         }
 
         return redirect()->intended(app()->make('config')->get('auth0.routes.home', '/'));


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

This PR:
- Updates our calls to the Laravel `app()` method to reference our own SDK. While the string approach works, there is potential for conflicts if that string gets inadvertently overwritten by the host application. This change ensures we're always referencing the correct class.
- Introduces minor code optimizations to fix linter warnings breaking CI.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
