### PR TITLE
[SDK-3576] Return interfaces instead of concrete classes

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -22,7 +22,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     /**
      * An instance of the Auth0-PHP SDK's SdkConfiguration, which handles configuration state.
      */
-    private ?\Auth0\SDK\Contract\ConfigurableContract $configuration = null;
+    private ?\Auth0\SDK\Configuration\SdkConfiguration $configuration = null;
 
     /**
      * @inheritdoc
@@ -51,7 +51,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     /**
      * @inheritdoc
      */
-    public function getConfiguration(): \Auth0\SDK\Contract\ConfigurableContract
+    public function getConfiguration(): \Auth0\SDK\Configuration\SdkConfiguration
     {
         if ($this->configuration === null) {
             $this->configuration = new \Auth0\SDK\Configuration\SdkConfiguration(app()->make('config')->get('auth0'));
@@ -64,7 +64,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
      * @inheritdoc
      */
     public function setConfiguration(
-        \Auth0\SDK\Contract\ConfigurableContract $configuration
+        \Auth0\SDK\Configuration\SdkConfiguration $configuration
     ): self {
         $this->configuration = $configuration;
         return $this;

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -17,17 +17,17 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     /**
      * An instance of the Auth0-PHP SDK.
      */
-    private ?\Auth0\SDK\Auth0 $sdk = null;
+    private ?\Auth0\SDK\Contract\Auth0Interface $sdk = null;
 
     /**
      * An instance of the Auth0-PHP SDK's SdkConfiguration, which handles configuration state.
      */
-    private ?\Auth0\SDK\Configuration\SdkConfiguration $configuration = null;
+    private ?\Auth0\SDK\Contract\ConfigurableContract $configuration = null;
 
     /**
      * @inheritdoc
      */
-    public function getSdk(): \Auth0\SDK\Auth0
+    public function getSdk(): \Auth0\SDK\Contract\Auth0Interface
     {
         if ($this->sdk === null) {
             $this->sdk = new \Auth0\SDK\Auth0($this->getConfiguration());
@@ -41,7 +41,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
      * @inheritdoc
      */
     public function setSdk(
-        \Auth0\SDK\Auth0 $sdk
+        \Auth0\SDK\Contract\Auth0Interface $sdk
     ): self {
         $this->sdk = $sdk;
         $this->setSdkTelemetry();
@@ -51,7 +51,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     /**
      * @inheritdoc
      */
-    public function getConfiguration(): \Auth0\SDK\Configuration\SdkConfiguration
+    public function getConfiguration(): \Auth0\SDK\Contract\ConfigurableContract
     {
         if ($this->configuration === null) {
             $this->configuration = new \Auth0\SDK\Configuration\SdkConfiguration(app()->make('config')->get('auth0'));
@@ -64,7 +64,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
      * @inheritdoc
      */
     public function setConfiguration(
-        \Auth0\SDK\Configuration\SdkConfiguration $configuration
+        \Auth0\SDK\Contract\ConfigurableContract $configuration
     ): self {
         $this->configuration = $configuration;
         return $this;
@@ -73,7 +73,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     /**
      * @inheritdoc
      */
-    public function getState(): \Auth0\Laravel\StateInstance
+    public function getState(): \Auth0\Laravel\Contract\StateInstance
     {
         return app()->make(\Auth0\Laravel\StateInstance::class);
     }

--- a/src/Contract/Auth0.php
+++ b/src/Contract/Auth0.php
@@ -21,13 +21,13 @@ interface Auth0
     /**
      * Create/return instance of the Auth0-PHP SdkConfiguration.
      */
-    public function getConfiguration(): \Auth0\SDK\Contract\ConfigurableContract;
+    public function getConfiguration(): \Auth0\SDK\Configuration\SdkConfiguration;
 
     /**
      * Assign the Auth0-PHP SdkConfiguration.
      */
     public function setConfiguration(
-        \Auth0\SDK\Contract\ConfigurableContract $configuration
+        \Auth0\SDK\Configuration\SdkConfiguration $configuration
     ): self;
 
     /**

--- a/src/Contract/Auth0.php
+++ b/src/Contract/Auth0.php
@@ -9,29 +9,29 @@ interface Auth0
     /**
      * Create/return instance of the Auth0-PHP SDK.
      */
-    public function getSdk(): \Auth0\SDK\Auth0;
+    public function getSdk(): \Auth0\SDK\Contract\Auth0Interface;
 
     /**
      * Create/return instance of the Auth0-PHP SDK.
      */
     public function setSdk(
-        \Auth0\SDK\Auth0 $sdk
+        \Auth0\SDK\Contract\Auth0Interface $sdk
     ): self;
 
     /**
      * Create/return instance of the Auth0-PHP SdkConfiguration.
      */
-    public function getConfiguration(): \Auth0\SDK\Configuration\SdkConfiguration;
+    public function getConfiguration(): \Auth0\SDK\Contract\ConfigurableContract;
 
     /**
      * Assign the Auth0-PHP SdkConfiguration.
      */
     public function setConfiguration(
-        \Auth0\SDK\Configuration\SdkConfiguration $configuration
+        \Auth0\SDK\Contract\ConfigurableContract $configuration
     ): self;
 
     /**
      * Create/create a request state instance, a storage singleton containing authenticated user data.
      */
-    public function getState(): \Auth0\Laravel\StateInstance;
+    public function getState(): \Auth0\Laravel\Contract\StateInstance;
 }


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR updates `Auth0\Laravel\Auth0` and the accompanying interface `Auth0\Laravel\Contract\Auth0` to return interfaces from methods, as opposed to concrete classes, to improve mockability for developers.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #295

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

See GitHub results, or run `composer install && vendor\bin\pest` within the cloned project directory on your machine.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
