### PR TITLE
[SDK-3585] Fix: `Missing Code` error on Callback Route for Octane Customers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 vendor/
+.idea/
 .env
 .DS_Store
 composer.lock

--- a/src/Http/Controller/Stateful/Callback.php
+++ b/src/Http/Controller/Stateful/Callback.php
@@ -20,7 +20,7 @@ final class Callback implements \Auth0\Laravel\Contract\Http\Controller\Stateful
 
         try {
             if ($request->query('state') !== null && $request->query('code') !== null) {
-                app(\Auth0\Laravel\Auth0::class)->getSdk()->exchange();
+                app(\Auth0\Laravel\Auth0::class)->getSdk()->exchange(null, $request->query('code'), $request->query('state'));
             }
         } catch (\Throwable $exception) {
             app(\Auth0\Laravel\Auth0::class)->getSdk()->clear();


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR resolves an issue for customers using our Laravel SDK with Laravel Octane.

**Bug:** With this combination, upon a user returning to the callback route (`Auth0\Laravel\Http\Controller\Stateful\Callback`) they would be presented with a `Missing Code` error.

**Cause:** The underlying Auth0 PHP SDK fetches the `code` and `state` parameters of the callback using the standard PHP super global `_GET`. This super global is not available when running Laravel under Octane. Within our Laravel SDK, we are (correctly) using Laravel's `Illuminate\Http\Request->query()` method to check for the presence of these values. However, we had not handed these values off directly to the underlying Auth0 PHP SDK, and instead allowed it to attempt to extract them itself from `_GET`, which would fail under Octane.

**Fix:** The Laravel SDK now correctly extracts these values using Octane-compatible Laravel APIs and hands them off to the underlying Auth0 PHP SDK directly, avoiding the conflict from the missing `_GET` super global.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves https://github.com/auth0/laravel-auth0/pull/218#issuecomment-1208503375

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
