### PR TITLE
Added viaRemember function to guard

### DIFF
--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -280,5 +280,4 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
     {
         return $this->provider;
     }
-
 }

--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -131,7 +131,7 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
     /**
      * Always returns false to keep third-party apps happy
      */
-    public function viaRemember()
+    public function viaRemember(): bool
     {
         return false;
     }

--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -127,6 +127,14 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
         $state = $this->getState();
         return in_array($scope, $state->getAccessTokenScope() ?? [], true);
     }
+    
+    /**
+     * Always returns false to keep third-party apps happy
+     */
+    public function viaRemember()
+    {
+        return false;
+    }
 
     /**
      * Get the user context from a provided access token.
@@ -272,4 +280,5 @@ final class Guard implements \Auth0\Laravel\Contract\Auth\Guard, \Illuminate\Con
     {
         return $this->provider;
     }
+
 }


### PR DESCRIPTION
I've found some third-party apps like Filament use the Auth::viaRemember() when checking auth status

<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
