### PR TITLE
[SDK-3715] Pin `psr/cache` dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "auth0/auth0-php": "^8.0",
         "illuminate/contracts": "^8.0 || ^9.0",
         "illuminate/http": "^8.0 || ^9.0",
-        "illuminate/support": "^8.0 || ^9.0"
+        "illuminate/support": "^8.0 || ^9.0",
+        "psr/cache": "^3.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "dev-main",


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR pins the `psr/cache` dependency (the standard interface spec for [PSR-6](https://www.php-fig.org/psr/psr-6/) to its PHP 8.0-targeted iteration, `^3.0`.

This dependency was previously implicitly required through the Auth0-PHP SDK, but because of our 7.4 support there, this allowed `^1.0 || ^2.0 || ^3.0`, which is no longer compatible downstream with this library.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #315 

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
