### PR TITLE
[SDK-3716] Do not require session configuration for stateless strategies

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -83,7 +83,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
                 // If no sessionStorage is defined, use an LaravelSession store instance.
                 if (! isset($config['sessionStorage'])) {
                     $configuration->setSessionStorage(
-                        transientStorage: new LaravelSession(
+                        sessionStorage: new LaravelSession(
                             prefix: $configuration->getSessionStorageId()
                         )
                     );

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -79,18 +79,24 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
 
             $configuration = new Configuration($config);
 
-            // If no sessionStorage is defined, use an LaravelSession store instance.
-            if (! isset($config['sessionStorage'])) {
-                $configuration->setSessionStorage(
-                    new LaravelSession($configuration->getSessionStorageId()),
-                );
-            }
+            if (! \in_array($configuration->getStrategy(), [Configuration::STRATEGY_API, Configuration::STRATEGY_MANAGEMENT_API], true)) {
+                // If no sessionStorage is defined, use an LaravelSession store instance.
+                if (! isset($config['sessionStorage'])) {
+                    $configuration->setSessionStorage(
+                        transientStorage: new LaravelSession(
+                            prefix: $configuration->getSessionStorageId()
+                        )
+                    );
+                }
 
-            // If no transientStorage is defined, use an LaravelSession store instance.
-            if (! isset($config['transientStorage'])) {
-                $configuration->setTransientStorage(
-                    new LaravelSession($configuration->getTransientStorageId()),
-                );
+                // If no transientStorage is defined, use an LaravelSession store instance.
+                if (! isset($config['transientStorage'])) {
+                    $configuration->setTransientStorage(
+                        transientStorage: new LaravelSession(
+                            prefix: $configuration->getTransientStorageId()
+                        )
+                    );
+                }
             }
 
             // Give apps an opportunity to mutate the configuration before applying it.


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR restores the previous (< 7.2.0) and intended behavior of only requiring a session configuration when an appropriate stateful strategy is configured by the host application.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #314 

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
