### PR TITLE
[SDK-3720] Restore `php artisan vendor:publish` command

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -50,6 +50,8 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider implemen
 
     public function boot(\Illuminate\Routing\Router $router, \Illuminate\Auth\AuthManager $auth): self
     {
+        $this->publishes([implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'config', 'auth0.php']) => config_path('auth0.php')], 'auth0-config');
+
         $auth->extend('auth0', static fn (): Guard => new Guard());
         $auth->provider('auth0', static fn (): Provider => new Provider());
 


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR restores the `php artisan vendor:publish --tag auto0-config` command that was available prior to 7.2 for generating the `auth0.php` config file for projects.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

See internal ticket SDK-3720

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

No additional testing is necessary for this change.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
