### PR TITLE
Release 7.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [7.2.2](https://github.com/auth0/laravel-auth0/tree/7.2.2) (2022-10-19)
+[Full Changelog](https://github.com/auth0/laravel-auth0/compare/7.2.1...7.2.2)
+
+**Fixed**
+- [SDK-3720] Restore `php artisan vendor:publish` command [\#321](https://github.com/auth0/laravel-auth0/pull/321) ([evansims](https://github.com/evansims))
+- [SDK-3721] Bump minimum `auth0/auth0-php` version to `^8.3.4` [\#322](https://github.com/auth0/laravel-auth0/pull/322) ([evansims](https://github.com/evansims))
+
 ## [7.2.1](https://github.com/auth0/laravel-auth0/tree/7.2.1) (2022-10-13)
 [Full Changelog](https://github.com/auth0/laravel-auth0/compare/7.2.0...7.2.1)
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -17,7 +17,7 @@ final class Auth0 implements \Auth0\Laravel\Contract\Auth0
     /**
      * The Laravel-Auth0 SDK version:.
      */
-    public const VERSION = '7.2.1';
+    public const VERSION = '7.2.2';
 
     /**
      * An instance of the Auth0-PHP SDK.


### PR DESCRIPTION

**Fixed**
- [SDK-3720] Restore `php artisan vendor:publish` command [\#321](https://github.com/auth0/laravel-auth0/pull/321) ([evansims](https://github.com/evansims))
- [SDK-3721] Bump minimum `auth0/auth0-php` version to `^8.3.4` [\#322](https://github.com/auth0/laravel-auth0/pull/322) ([evansims](https://github.com/evansims))


[SDK-3720]: https://auth0team.atlassian.net/browse/SDK-3720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-3721]: https://auth0team.atlassian.net/browse/SDK-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ