### PR TITLE
fix: Auth0\Laravel\Cache\LaravelCachePool::createItem returning a cache miss

### DIFF
--- a/src/Cache/LaravelCachePool.php
+++ b/src/Cache/LaravelCachePool.php
@@ -154,7 +154,7 @@ final class LaravelCachePool implements CacheItemPoolInterface
 
         $value = unserialize($value);
 
-        if (false === $value || 'b:0;' !== $value) {
+        if (false === $value) {
             return LaravelCacheItem::miss($key);
         }
 


### PR DESCRIPTION
Even when there is a value in the cache, it was still returning a miss, which made the caching practically unusable...
