### PR TITLE
fix: `env()` incorrectly assigns `cookieExpires` to a `string` value

### DIFF
--- a/config/auth0.php
+++ b/config/auth0.php
@@ -39,7 +39,7 @@ return [
     'cookieSecret' => env('AUTH0_COOKIE_SECRET', env('APP_KEY')),
 
     // How long, in seconds, before cookies expire. If set to 0 the cookie will expire at the end of the session (when the browser closes).
-    'cookieExpires' => env('COOKIE_EXPIRES', 0),
+    'cookieExpires' => (int) env('AUTH0_COOKIE_EXPIRES', 0),
 
     // Cookie domain, for example 'www.example.com', for use with PHP sessions and SDK cookies. Defaults to value of HTTP_HOST server environment information.
     // Note: To make cookies visible on all subdomains then the domain must be prefixed with a dot like '.example.com'.


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR resolves an issue reported by @affektde in #330 in which the `env()` helper method returns the `AUTH0_COOKIE_EXPIRES` value as a `string`, but the underlying PHP SDK expects an `int`.

This also fixes the environment variable mistakenly referenced as `COOKIE_EXPIRES` rather than `AUTH0_COOKIE_EXPIRES`.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #330 

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

Use `composer test` in a locally cloned repo, or review the GitHub status checks below.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
