### PR TITLE
Fix driver and provider names

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -25,8 +25,8 @@ final class ServiceProvider extends LaravelServiceProvider implements ServicePro
         $this->mergeConfigFrom(implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'config', 'auth0.php']), 'auth0');
         $this->publishes([implode(DIRECTORY_SEPARATOR, [__DIR__, '..', 'config', 'auth0.php']) => config_path('auth0.php')], 'auth0-config');
 
-        $auth->extend('auth0.guard', static fn (Application $app, string $name, array $config): Guard => new Guard($name, $config));
-        $auth->provider('auth0.provider', static fn (Application $app, array $config): Provider => new Provider($config));
+        $auth->extend('auth0', static fn (Application $app, string $name, array $config): Guard => new Guard($name, $config));
+        $auth->provider('auth0', static fn (Application $app, array $config): Provider => new Provider($config));
 
         $router->aliasMiddleware('auth0.authenticate.optional', AuthenticateOptional::class);
         $router->aliasMiddleware('auth0.authenticate', Authenticate::class);


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

I am using Laravel 10.4.1 and `auth0/login` 7.5.0.
I followed the [documentation](https://auth0.com/docs/quickstart/backend/laravel/01-authorization#configure-the-application) and encountered the following errors.

```
InvalidArgumentException: Auth driver [auth0] for guard [auth0] is not defined.
```
```
InvalidArgumentException: Authentication user provider [auth0] is not defined.
```

Fix the driver and provider names to resolve this.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
