### PR TITLE
Release 7.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [7.5.2](https://github.com/auth0/laravel-auth0/tree/7.5.2) (2023-04-10)
 
+**Fixed**
+
 -   Relaxed response types from middleware to use low-level `Symfony\Component\HttpFoundation\Response` class, allowing for broader and custom response types.
 
 ## [7.5.1](https://github.com/auth0/laravel-auth0/tree/7.5.1) (2023-04-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [7.5.2](https://github.com/auth0/laravel-auth0/tree/7.5.2) (2023-04-10)
+
 -   Relaxed response types from middleware to use low-level `Symfony\Component\HttpFoundation\Response` class, allowing for broader and custom response types.
 
 ## [7.5.1](https://github.com/auth0/laravel-auth0/tree/7.5.1) (2023-04-04)

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -25,7 +25,7 @@ final class Auth0 implements ServiceContract
      *
      * @var string
      */
-    public const VERSION = '7.5.1';
+    public const VERSION = '7.5.2';
 
     public function __construct(
         private ?SDKContract $sdk = null,


### PR DESCRIPTION
**Fixed**

-   Relaxed response types from middleware to use low-level `Symfony\Component\HttpFoundation\Response` class, allowing for broader and custom response types.