### PR TITLE
feature: Auth middleware will now setIntendedUrl() before login redirect

### DIFF
--- a/src/Http/Middleware/Stateful/Authenticate.php
+++ b/src/Http/Middleware/Stateful/Authenticate.php
@@ -47,6 +47,8 @@ final class Authenticate extends MiddlewareAbstract implements AuthenticateContr
             abort(Response::HTTP_FORBIDDEN, 'Forbidden');
         }
 
-        return redirect()->to(config('auth0.routes.login', 'login')); // @phpstan-ignore-line
+        return redirect()
+            ->setIntendedUrl($request->fullUrl())
+            ->to(config('auth0.routes.login', 'login')); // @phpstan-ignore-line
     }
 }

--- a/tests/Unit/Http/Middleware/Stateful/AuthenticateTest.php
+++ b/tests/Unit/Http/Middleware/Stateful/AuthenticateTest.php
@@ -67,6 +67,9 @@ it('redirects to login route if a visitor does not have a session', function ():
     $this->get($route)
          ->assertRedirect($config['auth0.routes.login']);
 
+    expect(redirect()->getIntendedUrl())
+        ->toEqual('http://localhost' . $route);
+
     expect($this->guard)
          ->user()->toBeNull();
 });


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR updates the `Auth0\Laravel\Http\Middleware\Stateful\Authenticate` route middleware to `setIntendedUrl()` from an intercepted request before issuing the redirect to the login route.

The callback route was already configured to issue redirects after login that default to honouring any assigned intended URLs, so no other changes are necessary elsewhere.

To illustrate this process:
- Visitor requests `/protected-route`.
- `auth0.authorize` middleware determines visitor is not authenticated.
- `auth0.authorize` makes note that the visitor was trying to access `/protected-route`.
- `auth0.authorize` redirects to `/login` to kick off the authentication flow.
- Visitor completes the authentication flow, and is dropped back off to `/callback`.
- `Auth0\Laravel\Http\Controller\Stateful` (the `/callback` controller) completes the code exchange, and validates the session.
- `Auth0\Laravel\Http\Controller\Stateful` issues a `redirect()->intended(...)`, which picks up the intended URL that `auth0.authorize` noted earlier.
- Visitor is redirected to `/protected-route`, now with an authenticated session.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #357 

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

Tests have been updated to cover this new feature.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
