### PR TITLE
fix: legacyGuardUserMethod should use `$session` not `$token`

### DIFF
--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -581,7 +581,7 @@ final class Guard implements GuardContract
             $session = $this->find(self::SOURCE_SESSION);
 
             if ($session instanceof Credential) {
-                $this->login($token, self::SOURCE_SESSION);
+                $this->login($session, self::SOURCE_SESSION);
 
                 return $this->getCredential()?->getUser();
             }


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR addresses a bug where `legacyGuardUserMethod` behaviour mistakenly consumes `$token` instead of `$session` for automatic logins during `user()` calls.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #363 

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

Tests are passing. No additions were necessary to cover this change.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
