### PR TITLE
Release 7.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -22,6 +22,7 @@ body:
       label: SDK Version
       description: What version of our Laravel plugin are you running? (`composer show | grep auth0/login`)
       options:
+        - SDK 7.6
         - SDK 7.5
         - SDK 7.4
         - SDK 7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [7.6.0](https://github.com/auth0/laravel-auth0/tree/7.6.0) (2023-04-10)
+## [7.6.0](https://github.com/auth0/laravel-auth0/tree/7.6.0) (2023-04-12)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [7.6.0](https://github.com/auth0/laravel-auth0/tree/7.6.0) (2023-04-10)
 
 ### Added
 

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -25,7 +25,7 @@ final class Auth0 implements ServiceContract
      *
      * @var string
      */
-    public const VERSION = '7.5.2';
+    public const VERSION = '7.6.0';
 
     public function __construct(
         private ?SDKContract $sdk = null,


### PR DESCRIPTION
### Added

-   `Auth0\Laravel\Http\Middleware\Guard`, new middleware that forces Laravel to route requests through a group using a specific Guard. ([\#362](https://github.com/auth0/laravel-auth0/pull/362))

### Improved

-   `Auth0\Laravel\Http\Middleware\Stateful\Authenticate` now remembers the intended route (using `redirect()->setIntendedUrl()`) before kicking off authentication flow redirect. Users will be returned to the memorized intended route after completing their authentication flow. ([\#364](https://github.com/auth0/laravel-auth0/pull/364))

### Fixed

-   legacyGuardUserMethod behavior should use `$session`, not `$token` ([\#353](https://github.com/auth0/laravel-auth0/pull/365))