### PR TITLE
feature: Add `refreshUser()` method to Guard

### DIFF
--- a/src/Auth/Guard.php
+++ b/src/Auth/Guard.php
@@ -566,9 +566,16 @@ final class Guard implements GuardContract
 
             if (HttpResponse::wasSuccessful($response)) {
                 $response = HttpResponse::decodeContent($response);
-                $response = $this->getProvider()->retrieveByCredentials($this->normalizeUserArray($response));
-                $this->getCredential()->setUser($response);
-                $this->pushState();
+                $user = $this->getProvider()->retrieveByCredentials($response);
+
+                $this->pushState(CredentialConcrete::create(
+                    user: $user,
+                    idToken: $this->getCredential()->getIdToken(),
+                    accessToken: $this->getCredential()->getAccessToken(),
+                    accessTokenScope: $this->getCredential()->getAccessTokenScope(),
+                    accessTokenExpiration: $this->getCredential()->getAccessTokenExpiration(),
+                    refreshToken: $this->getCredential()->getRefreshToken(),
+                ));
             }
         }
     }

--- a/src/Contract/Auth/Guard.php
+++ b/src/Contract/Auth/Guard.php
@@ -140,6 +140,11 @@ interface Guard extends GuardContract
     ): void;
 
     /**
+     * Query the /userinfo endpoint and update the currently authenticated user for the guard.
+     */
+    public function refreshUser(): void;
+
+    /**
      * Returns the currently authenticated user for the guard, if available.
      */
     public function user(): ?Authenticatable;


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR adds a `refreshUser()` method to the SDK's Guard API; it wraps up calling the `/userinfo` endpoint to retrieve updated data for the authenticated user. This is intended as a convenience helper to reflect changes issued to the Management API without requiring a user to re-authenticate.

Usage:
```php
<?PHP
$sdk = app('auth0');
$guard = app('auth0.guard');

$guard->setUser('auth0|...');

echo $guard->user()->name; // John Doe

$sdk->management()->users()->update(
  user: $guard->user()->getAuthIdentifier(), 
  body: [
    'name' => 'Jane Doe'
  ]
);

$guard->refreshUser();
echo $guard->user()->name; // Jane Doe
```

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Jira: SDK-4148

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

- Tests have been added to cover this new method.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
