### PR TITLE
feature: Add `management()` to SDK service as a Management API convenience method

### DIFF
--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -34,11 +34,6 @@ final class Auth0 implements ServiceContract
     ) {
     }
 
-    public function management(): ManagementInterface
-    {
-        return $this->getSdk()->management();
-    }
-
     /**
      * Updates the Auth0 PHP SDK's telemetry to include the correct Laravel markers.
      */
@@ -119,6 +114,11 @@ final class Auth0 implements ServiceContract
         }
 
         return $this->setSdk(new SDK($this->getConfiguration()));
+    }
+
+    public function management(): ManagementInterface
+    {
+        return $this->getSdk()->management();
     }
 
     public function reset(): self

--- a/src/Auth0.php
+++ b/src/Auth0.php
@@ -10,6 +10,7 @@ use Auth0\Laravel\Event\Configuration\{Building, Built};
 use Auth0\Laravel\Store\LaravelSession;
 use Auth0\SDK\Auth0 as SDK;
 use Auth0\SDK\Configuration\SdkConfiguration as Configuration;
+use Auth0\SDK\Contract\API\ManagementInterface;
 use Auth0\SDK\Contract\Auth0Interface as SDKContract;
 use Auth0\SDK\Utility\HttpTelemetry;
 
@@ -31,6 +32,11 @@ final class Auth0 implements ServiceContract
         private ?SDKContract $sdk = null,
         private ?Configuration $configuration = null,
     ) {
+    }
+
+    public function management(): ManagementInterface
+    {
+        return $this->getSdk()->management();
     }
 
     /**

--- a/src/Contract/Auth0.php
+++ b/src/Contract/Auth0.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\Laravel\Contract;
 
 use Auth0\SDK\Configuration\SdkConfiguration as Configuration;
+use Auth0\SDK\Contract\API\ManagementInterface;
 use Auth0\SDK\Contract\Auth0Interface as SDK;
 
 interface Auth0
@@ -18,6 +19,11 @@ interface Auth0
      * Create/return instance of the Auth0-PHP SDK.
      */
     public function getSdk(): SDK;
+
+    /**
+     * Returns an instance of the Management API class.
+     */
+    public function management(): ManagementInterface;
 
     /**
      * Resets and cleans up the internal state of the SDK.

--- a/tests/Unit/Auth0Test.php
+++ b/tests/Unit/Auth0Test.php
@@ -3,11 +3,16 @@
 declare(strict_types=1);
 
 use Auth0\SDK\Contract\Auth0Interface as SdkContract;
-use Auth0\Laravel\Auth0;
 use Auth0\SDK\Auth0 as SDKAuth0;
 use Auth0\SDK\Configuration\SdkConfiguration;
+use Auth0\SDK\Contract\API\ManagementInterface;
 
 uses()->group('auth0');
+
+it('returns a Management API class', function (): void {
+    $laravel = app('auth0');
+    expect($laravel->management())->toBeInstanceOf(ManagementInterface::class);
+});
 
 it('can get/set the configuration', function (): void {
     $laravel = app('auth0');


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to commiting work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This PR adds a `management()` convenience method to the SDK's Laravel service container. It saves writing a small amount of redundant boilerplate in order to access the Management API classes from the underlying PHP SDK.

Before this change:
```php
<?php

app('auth0')
  ->getSdk()
  ->management()
  ->...
```

After this change:
```php
<?php

app('auth0')
  ->management()
  ->...
```

Admittedly a minuscule change, but it better illustrates that the Management API is an integral part of the SDK, and is easily accessible to the host application.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

N/A

### Testing

<!--
  Would you please describe how reviewers can test this?
  Be specific about anything not tested and the reasons why.
  Tests must be added for new functionality, and existing tests should complete without errors.
-->

Tests have been added to cover the new method.

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
