### PR TITLE
Fix: Exception when parsing `.env` with comments

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -294,6 +294,8 @@ final class Configuration implements ConfigurationContract
 
     /**
      * @codeCoverageIgnore
+     *
+     * @psalm-suppress DocblockTypeContradiction
      */
     public static function getEnvironment(): array
     {
@@ -323,7 +325,22 @@ final class Configuration implements ConfigurationContract
                 }
 
                 foreach ($contents as $content) {
+                    if (1 !== mb_substr_count($content, '=')) {
+                        continue;
+                    }
+
                     [$k,$v] = explode('=', $content);
+
+                    // @phpstan-ignore-next-line
+                    if (! is_string($k)) {
+                        continue;
+                    }
+
+                    // @phpstan-ignore-next-line
+                    if (! is_string($v)) {
+                        continue;
+                    }
+
                     $v = trim($v);
 
                     if ('' === $v) {


### PR DESCRIPTION
<!--
  Please only send a pull request to branches that are currently supported.
  Pull requests without a descriptive title, thorough description, or tests will be closed.
  -
  When proposing enhancements, please ensure you have created an Issue and given our engineers time to
  review your suggestion there prior to committing to work.
-->

### Changes

<!--
  Would you please describe both what is changing and why this is important?
  Explain the benefit to end-users, why it does not break any existing features, how it makes building applications easier, etc.
-->

This resolves an issue with parsing `.env` files that contain lines without standard key-value strings, such as `# Comments`.

### References

<!--
  All pull requests should link to an associated issue tagged 'selected for development' by an Auth0 engineer.
-->

Resolves #394

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
