### PR TITLE
[SDK-4337] feat: Add setting to define search path for configuration files

### DIFF
--- a/config/auth0.php
+++ b/config/auth0.php
@@ -9,6 +9,7 @@ return Configuration::VERSION_2 + [
     'registerGuards' => true,
     'registerMiddleware' => true,
     'registerAuthenticationRoutes' => true,
+    'configurationPath' => null,
 
     'guards' => [
         'default' => [

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -412,7 +412,13 @@ final class Configuration implements ConfigurationContract
     public static function getPath(): string
     {
         if (null === self::$path) {
-            self::$path = base_path() . DIRECTORY_SEPARATOR;
+            $path = config('auth0.configurationPath');
+
+            if (! is_string($path)) {
+                $path = base_path() . DIRECTORY_SEPARATOR;
+            }
+
+            self::$path = $path;
         }
 
         return self::$path;


### PR DESCRIPTION
<!--
  Please only send pull requests to branches that are actively supported.
  Pull requests without an adequate title, description, or tests will be closed.
-->

### Changes

<!--
  What is changing, and why this is important?
-->

This PR adds an optional `configurationPath` setting to the `config/auth0.php` SDK configuration file for applications, which allows developers to specify the search path the SDK will use to search for configuration files (.auth0.*.json, .env*).

### References

<!--
  Link to any associated issues.
-->

Closes #397 

### Testing

<!--
  Tests must be added for new functionality, and existing tests should complete without errors.
  100% test coverage is required.
-->

Test coverage remains at 100%.

### Contributor Checklist

-   [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
