### PR TITLE
[SDK-4337] fix: Restore host environment variable processing

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -540,6 +540,8 @@ final class Configuration implements ConfigurationContract
         string $setting,
         array | bool | string | int | null $default = null,
     ): array | bool | string | int | null {
+        $value = null;
+
         if (defined('AUTH0_OVERRIDE_CONFIGURATION')) {
             $override = constant('AUTH0_OVERRIDE_CONFIGURATION');
 
@@ -549,7 +551,12 @@ final class Configuration implements ConfigurationContract
         } else {
             $env = 'AUTH0_' . strtoupper(Str::snake($setting));
             $json = self::CONFIG_AUDIENCE === $setting ? 'identifier' : Str::snake($setting);
-            $value = self::getEnvironment()[$env] ?? self::getJson()[$json] ?? $default;
+            $value = $_ENV[$env] ?? self::getEnvironment()[$env] ?? self::getJson()[$json] ?? $default;
+        }
+
+        if (! is_string($value) && ! is_array($value) && ! is_bool($value) && ! is_int($value)) {
+            $value = null;
+        }
         }
 
         return $value ?? $default;

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -557,7 +557,6 @@ final class Configuration implements ConfigurationContract
         if (! is_string($value) && ! is_array($value) && ! is_bool($value) && ! is_int($value)) {
             $value = null;
         }
-        }
 
         return $value ?? $default;
     }


### PR DESCRIPTION
<!--
  Please only send pull requests to branches that are actively supported.
  Pull requests without an adequate title, description, or tests will be closed.
-->

### Changes

<!--
  What is changing, and why this is important?
-->

This PR restore previous host environment variable configurations, in addition to the "dotenv" and JSON-based configuration methods.

### References

<!--
  Link to any associated issues.
-->

Closes #405 

### Testing

<!--
  Tests must be added for new functionality, and existing tests should complete without errors.
  100% test coverage is required.
-->

Test coverage remains at 100%.

### Contributor Checklist

-   [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
