### PR TITLE
[SDK-4337] fix: Trim quote characters from around environment variable strings

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -552,6 +552,10 @@ final class Configuration implements ConfigurationContract
             $value = self::getEnvironment()[$env] ?? self::getJson()[$json] ?? $default;
         }
 
+        if (is_string($value)) {
+            $value = trim($value, '\'"');
+        }
+
         return $value ?? $default;
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -540,6 +540,8 @@ final class Configuration implements ConfigurationContract
         string $setting,
         array | bool | string | int | null $default = null,
     ): array | bool | string | int | null {
+        $value = null;
+
         if (defined('AUTH0_OVERRIDE_CONFIGURATION')) {
             $override = constant('AUTH0_OVERRIDE_CONFIGURATION');
 


### PR DESCRIPTION
<!--
  Please only send pull requests to branches that are actively supported.
  Pull requests without an adequate title, description, or tests will be closed.
-->

### Changes

<!--
  What is changing, and why this is important?
-->

This PR resolves an issue where quote characters (`'`, or `"`) are not removed from strings when pulling values from `dotenv` files. Although these quotes are always optional, it is common practice to use them. This was previous behavior before the 7.7 configuration system improvements.

### References

<!--
  Link to any associated issues.
-->

Closes #399 

### Testing

<!--
  Tests must be added for new functionality, and existing tests should complete without errors.
  100% test coverage is required.
-->

Testing remains at 100%.

### Contributor Checklist

-   [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
