### PR TITLE
[SDK-4338] feat: `GuardAbstract` extends `Illuminate\Contracts\Auth\Guard`

### DIFF
--- a/src/Guards/GuardAbstract.php
+++ b/src/Guards/GuardAbstract.php
@@ -12,7 +12,7 @@ use Auth0\SDK\Contract\Auth0Interface;
 use Auth0\SDK\Exception\InvalidTokenException;
 use Auth0\SDK\Token;
 use Exception;
-use Illuminate\Contracts\Auth\{Authenticatable, UserProvider};
+use Illuminate\Contracts\Auth\{Authenticatable, Guard, UserProvider};
 use Illuminate\Contracts\Session\Session;
 use Illuminate\Contracts\Support\{Arrayable, Jsonable};
 use JsonSerializable;
@@ -27,7 +27,7 @@ use function is_string;
  *
  * @api
  */
-abstract class GuardAbstract
+abstract class GuardAbstract implements Guard
 {
     protected ?CredentialEntityContract $credential = null;
 


### PR DESCRIPTION
<!--
  Please only send pull requests to branches that are actively supported.
  Pull requests without an adequate title, description, or tests will be closed.
-->

### Changes

<!--
  What is changing, and why this is important?
-->

This PR updates `Auth0\Laravel\Guards\GuardAbstract` abstract class (which is extended by the concrete `Auth0\Laravel\Guards\AuthenticationGuard` and `Auth0\Laravel\Guards\AuthorizationGuard` classes) to extend the `Illuminate\Contracts\Auth\Guard` interface. This is a framework interface provided by Laravel.

No functional changes related to this change, but extending it is suggested as a best practice.

### References

<!--
  Link to any associated issues.
-->

Addresses feedback from @devfrey in #385.

### Testing

<!--
  Tests must be added for new functionality, and existing tests should complete without errors.
  100% test coverage is required.
-->

Test coverage remains at 100%.

### Contributor Checklist

-   [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
