### PR TITLE
fix: Remove redundant middleware insertion

### DIFF
--- a/src/Middleware/GuardMiddleware.php
+++ b/src/Middleware/GuardMiddleware.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Auth0\Laravel\Middleware;
 
-use Illuminate\Http\Request;
-
 /**
  * Assigns a specific guard to the request.
  *

--- a/src/ServiceProviderAbstract.php
+++ b/src/ServiceProviderAbstract.php
@@ -19,7 +19,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
-use function defined;
 use function is_string;
 
 /**
@@ -208,7 +207,6 @@ abstract class ServiceProviderAbstract extends ServiceProvider
             /**
              * @var \Illuminate\Foundation\Http\Kernel $kernel
              */
-
             $kernel->appendMiddlewareToGroup('web', AuthenticatorMiddleware::class);
             $kernel->appendMiddlewareToGroup('api', AuthorizerMiddleware::class);
 

--- a/src/ServiceProviderAbstract.php
+++ b/src/ServiceProviderAbstract.php
@@ -208,10 +208,6 @@ abstract class ServiceProviderAbstract extends ServiceProvider
             /**
              * @var \Illuminate\Foundation\Http\Kernel $kernel
              */
-            if (! defined('AUTH0_LARAVEL_RUNNING_TESTS')) {
-                $kernel->pushMiddleware(AuthenticatorMiddleware::class);
-                $kernel->pushMiddleware(AuthenticatorMiddleware::class);
-            }
 
             $kernel->appendMiddlewareToGroup('web', AuthenticatorMiddleware::class);
             $kernel->appendMiddlewareToGroup('api', AuthorizerMiddleware::class);


### PR DESCRIPTION
<!--
  Please only send pull requests to branches that are actively supported.
  Pull requests without an adequate title, description, or tests will be closed.
-->

### Changes

<!--
  What is changing, and why this is important?
-->

This PR removes a redundant middleware insertion call that in some circumstances could cause the session-based authentication guard to be invoked during stateless/token-based authorization requests.

### References

<!--
  Link to any associated issues.
-->

### Testing

<!--
  Tests must be added for new functionality, and existing tests should complete without errors.
  100% test coverage is required.
-->

### Contributor Checklist

-   [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
