### PR TITLE
ensure auth0 middleware is prioritized to load before others

### DIFF
--- a/src/ServiceProviderAbstract.php
+++ b/src/ServiceProviderAbstract.php
@@ -208,7 +208,9 @@ abstract class ServiceProviderAbstract extends ServiceProvider
              * @var \Illuminate\Foundation\Http\Kernel $kernel
              */
             $kernel->appendMiddlewareToGroup('web', AuthenticatorMiddleware::class);
+            $kernel->prependToMiddlewarePriority(AuthenticatorMiddleware::class);
             $kernel->appendMiddlewareToGroup('api', AuthorizerMiddleware::class);
+            $kernel->prependToMiddlewarePriority(AuthorizerMiddleware::class);
 
             $router->pushMiddlewareToGroup('web', AuthenticatorMiddleware::class);
             $router->pushMiddlewareToGroup('api', AuthorizerMiddleware::class);


### PR DESCRIPTION
### Changes

Ensure auth0 middleware is prioritized to load before other middleware that expect auth to have been completed, such as middleware for Laravel Inetrtia, Laravel Nova.

### References

Fixes https://github.com/auth0/laravel-auth0/issues/414