### PR TITLE
fix: Ignore default AUTH0_ dotenv values

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -557,23 +557,22 @@ final class Configuration implements ConfigurationContract
         } else {
             $env = 'AUTH0_' . strtoupper(Str::snake($setting));
             $json = self::CONFIG_AUDIENCE === $setting ? 'identifier' : Str::snake($setting);
-            $value = $_ENV[$env] ?? self::getEnvironment()[$env] ?? null;
 
-            if (self::CONFIG_DOMAIN === $setting && '{DOMAIN}' === $value) {
+            $value = getenv($env);
+
+            if (! is_string($value)) {
                 $value = null;
             }
 
-            if (self::CONFIG_CLIENT_ID === $setting && '{CLIENT_ID}' === $value) {
-                $value = null;
-            }
+            $value ??= self::getEnvironment()[$env] ?? null;
 
-            if (self::CONFIG_CLIENT_SECRET === $setting && '{CLIENT_SECRET}' === $value) {
-                $value = null;
-            }
-
-            if (self::CONFIG_AUDIENCE === $setting && '{API_IDENTIFIER}' === $value) {
-                $value = null;
-            }
+            $value = match ($setting) {
+                self::CONFIG_DOMAIN => '{DOMAIN}' === $value ? null : $value,
+                self::CONFIG_CLIENT_ID => '{CLIENT_ID}' === $value ? null : $value,
+                self::CONFIG_CLIENT_SECRET => '{CLIENT_SECRET}' === $value ? null : $value,
+                self::CONFIG_AUDIENCE => '{API_IDENTIFIER}' === $value ? null : $value,
+                default => $value,
+            };
 
             $value ??= self::getJson()[$json] ?? $default;
         }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -557,7 +557,25 @@ final class Configuration implements ConfigurationContract
         } else {
             $env = 'AUTH0_' . strtoupper(Str::snake($setting));
             $json = self::CONFIG_AUDIENCE === $setting ? 'identifier' : Str::snake($setting);
-            $value = $_ENV[$env] ?? self::getEnvironment()[$env] ?? self::getJson()[$json] ?? $default;
+            $value = $_ENV[$env] ?? self::getEnvironment()[$env] ?? null;
+
+            if (self::CONFIG_DOMAIN === $setting && '{DOMAIN}' === $value) {
+                $value = null;
+            }
+
+            if (self::CONFIG_CLIENT_ID === $setting && '{CLIENT_ID}' === $value) {
+                $value = null;
+            }
+
+            if (self::CONFIG_CLIENT_SECRET === $setting && '{CLIENT_SECRET}' === $value) {
+                $value = null;
+            }
+
+            if (self::CONFIG_AUDIENCE === $setting && '{API_IDENTIFIER}' === $value) {
+                $value = null;
+            }
+
+            $value ??= self::getJson()[$json] ?? $default;
         }
 
         if (! is_string($value) && ! is_array($value) && ! is_bool($value) && ! is_int($value)) {

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -83,6 +83,29 @@ test('stringOrIntToIntOrNull() behaves as expected', function (): void {
         ->toBeNull();
 });
 
+test('get() ignores quickstart placeholders', function (): void {
+    putenv('AUTH0_DOMAIN={DOMAIN}');
+    putenv('AUTH0_CLIENT_ID={CLIENT_ID}');
+    putenv('AUTH0_CLIENT_SECRET={CLIENT_SECRET}');
+    putenv('AUTH0_AUDIENCE={API_IDENTIFIER}');
+    putenv('AUTH0_CUSTOM_DOMAIN=https://example.com');
+
+    expect(Configuration::get(Configuration::CONFIG_CUSTOM_DOMAIN))
+        ->toBeString('https://example.com');
+
+    expect(Configuration::get(Configuration::CONFIG_DOMAIN))
+        ->toBeNull();
+
+    expect(Configuration::get(Configuration::CONFIG_CLIENT_ID))
+        ->toBeNull();
+
+    expect(Configuration::get(Configuration::CONFIG_CLIENT_SECRET))
+        ->toBeNull();
+
+    expect(Configuration::get(Configuration::CONFIG_AUDIENCE))
+        ->toBeNull();
+});
+
 test('get() behaves as expected', function (): void {
     config(['test' => [
         Configuration::CONFIG_AUDIENCE => implode(',', [uniqid(), uniqid()]),


### PR DESCRIPTION
<!--
  Please only send pull requests to branches that are actively supported.
  Pull requests without an adequate title, description, or tests will be closed.
-->

### Changes

This PR fixes an issue where, out of the box, the Laravel QS does not properly have the placeholder dotenv values ignored when a JSON configuration is used, resulting in validation errors, as environment variables always take priority.

<!--
  What is changing, and why this is important?
-->

### References

<!--
  Link to any associated issues.
-->

### Testing

<!--
  Tests must be added for new functionality, and existing tests should complete without errors.
  100% test coverage is required.
-->

### Contributor Checklist

-   [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [ ] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
