### PR TITLE
fix: Inject Guards into MiddlewarePriority manifest

### DIFF
--- a/src/ServiceProviderAbstract.php
+++ b/src/ServiceProviderAbstract.php
@@ -209,10 +209,10 @@ abstract class ServiceProviderAbstract extends ServiceProvider
              * @var \Illuminate\Foundation\Http\Kernel $kernel
              */
             $kernel->appendMiddlewareToGroup('web', AuthenticatorMiddleware::class);
-            $kernel->appendMiddlewareToGroup('api', AuthorizerMiddleware::class);
+            $kernel->prependToMiddlewarePriority(AuthenticatorMiddleware::class);
 
-            $router->pushMiddlewareToGroup('web', AuthenticatorMiddleware::class);
-            $router->pushMiddlewareToGroup('api', AuthorizerMiddleware::class);
+            $kernel->appendMiddlewareToGroup('api', AuthorizerMiddleware::class);
+            $kernel->prependToMiddlewarePriority(AuthorizerMiddleware::class);
         }
     }
 


### PR DESCRIPTION
<!--
  Please only send pull requests to branches that are actively supported.
  Pull requests without an adequate title, description, or tests will be closed.
-->

### Changes

<!--
  What is changing, and why this is important?
-->

This PR updates the guard middleware registration process to prepend the SDK's guards to the MiddlewarePriority manifest, ensuring they are loaded before `Illuminate\Auth\Middleware\Authenticate`.

`Illuminate\Auth\Middleware\Authenticate` is automatically registered as a priority middleware by Laravel by default. This class includes a `authenticate()` method, which can cause issues (e.g. infinite loops, etc.) when it incorrectly determines a guard is not available.

### References

<!--
  Link to any associated issues.
-->

### Testing

<!--
  Tests must be added for new functionality, and existing tests should complete without errors.
  100% test coverage is required.
-->

### Contributor Checklist

-   [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [ ] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
