### PR TITLE
fix: `CacheBridgeAbstract::save()` not assigning value to cache when cache hit mises

### DIFF
--- a/src/Bridges/CacheBridgeAbstract.php
+++ b/src/Bridges/CacheBridgeAbstract.php
@@ -118,7 +118,7 @@ abstract class CacheBridgeAbstract extends BridgeAbstract
             return false;
         }
 
-        $value = serialize($item->get());
+        $value = serialize($item->getRawValue());
         $key = $item->getKey();
         $expires = $item->getExpiration();
 

--- a/tests/Unit/Bridges/CacheBridgeTest.php
+++ b/tests/Unit/Bridges/CacheBridgeTest.php
@@ -36,9 +36,7 @@ test('getItem(), hasItem() and save() behave as expected', function (): void {
     expect($cache)
         ->toBeInstanceOf(CacheItemBridge::class)
         ->isHit()->toBeTrue()
-        ->get()->toBeNull()
-        ->set(42)
-        ->get()->toBe(42);
+        ->get()->toEqual(42);
 
     $results = $pool->getItems();
 
@@ -46,12 +44,12 @@ test('getItem(), hasItem() and save() behave as expected', function (): void {
         ->toBeArray()
         ->toHaveCount(0);
 
-    $results = $pool->getItems(['testing' => uniqid()]);
+    $results = $pool->getItems(['testing']);
 
     expect($results['testing'])
         ->toBeInstanceOf(CacheItemBridge::class)
         ->isHit()->toBeTrue()
-        ->get()->not()->toBe(42);
+        ->get()->toEqual(42);
 
     $this->app[\Illuminate\Cache\CacheManager::class]
         ->getStore()


### PR DESCRIPTION
<!--
  Please only send pull requests to branches that are actively supported.
  Pull requests without an adequate title, description, or tests will be closed.
-->

### Changes

This PR updates cache save value. 
According to the Auth0\Laravel\Bridges\CacheItemBridgeAbstract::get(), the item value always returns null because `isHit()` is false til the value is cached, and as a result, the cache is not working properly.

```php
    final public function get(): mixed
    {
        return $this->isHit() ? $this->value : null;
    }
``` 

So for cache save function, we need to use `getRawValue(),` which is not dependent on hit status.
 
### References

<!--
  Link to any associated issues.
-->

### Testing

<!--
  Tests must be added for new functionality, and existing tests should complete without errors.
  100% test coverage is required.
-->

### Contributor Checklist

-   [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
