### PR TITLE
fix: Correct syntax error in Auth Guard for substantial performance gains

### DIFF
--- a/src/Guards/AuthenticationGuard.php
+++ b/src/Guards/AuthenticationGuard.php
@@ -92,7 +92,7 @@ final class AuthenticationGuard extends GuardAbstract implements AuthenticationG
             return $this->getImposter();
         }
 
-        if ($this->credential instanceof CredentialEntityContract) {
+        if (!$this->credential instanceof CredentialEntityContract) {
             $updated = $this->findSession();
             $this->setCredential($updated);
             $this->pushState($updated);


### PR DESCRIPTION
### Changes

Current code is finding session, setting credential and pushing state with every call to getCredential(). Fix replaces missing NOT operator so code correctly uses cached credential if available.

### Testing

We have several pages in our app which return collections of tens of thousands of Eloquent records. After installing laravel-auth0 we noticed the performance of these pages degrade by 2x-6x depending on the records involved, sometimes resulting in timeout errors. With the fix in place, performance has returned to normal. 

### Contributor Checklist

-   [X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [X ] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
