### PR TITLE
perf: Update getCredential to only refresh credential once per request

### DIFF
--- a/src/Guards/AuthenticationGuard.php
+++ b/src/Guards/AuthenticationGuard.php
@@ -32,6 +32,11 @@ final class AuthenticationGuard extends GuardAbstract implements AuthenticationG
      */
     protected const TELESCOPE = '\Laravel\Telescope\Telescope';
 
+    /**
+     * @var bool
+     */
+    private bool $didCredRefresh = false;
+
     public function find(): ?CredentialEntityContract
     {
         if ($this->isImpersonating()) {
@@ -92,10 +97,15 @@ final class AuthenticationGuard extends GuardAbstract implements AuthenticationG
             return $this->getImposter();
         }
 
+        if (!empty($this->didCredRefresh)) {
+            return $this->credential;
+        }
+
         if ($this->credential instanceof CredentialEntityContract) {
             $updated = $this->findSession();
             $this->setCredential($updated);
             $this->pushState($updated);
+            $this->didCredRefresh = true;
         }
 
         return $this->credential;

--- a/src/Guards/AuthenticationGuard.php
+++ b/src/Guards/AuthenticationGuard.php
@@ -32,9 +32,6 @@ final class AuthenticationGuard extends GuardAbstract implements AuthenticationG
      */
     protected const TELESCOPE = '\Laravel\Telescope\Telescope';
 
-    /**
-     * @var bool
-     */
     private bool $didCredRefresh = false;
 
     public function find(): ?CredentialEntityContract
@@ -97,7 +94,7 @@ final class AuthenticationGuard extends GuardAbstract implements AuthenticationG
             return $this->getImposter();
         }
 
-        if (!empty($this->didCredRefresh)) {
+        if ($this->didCredRefresh) {
             return $this->credential;
         }
 

--- a/src/Guards/AuthenticationGuard.php
+++ b/src/Guards/AuthenticationGuard.php
@@ -95,12 +95,12 @@ final class AuthenticationGuard extends GuardAbstract implements AuthenticationG
         }
 
         if ($this->credential instanceof CredentialEntityContract) {
-            $updated = $this->findSession();
-            $updatedCredThumbprint = $this->getCredThumbprint($updated);
-            if ($updatedCredThumbprint !== $this->credThumbprint) {
+            $currThumbprint = $this->getCredThumbprint($this->sdk()->getCredentials());
+            if ($currThumbprint !== $this->credThumbprint) {
+                $updated = $this->findSession();
                 $this->setCredential($updated);
                 $this->pushState($updated);
-                $this->credThumbprint = $updatedCredThumbprint;
+                $this->credThumbprint = $currThumbprint;
             }
         }
 
@@ -246,7 +246,6 @@ final class AuthenticationGuard extends GuardAbstract implements AuthenticationG
         $this->stopImpersonating();
 
         $this->credential = $credential;
-        $this->credThumbprint = $this->getCredThumbprint($credential);
 
         return $this;
     }
@@ -338,9 +337,9 @@ final class AuthenticationGuard extends GuardAbstract implements AuthenticationG
         return $lastResponse = null;
     }
 
-    private function getCredThumbprint(?CredentialEntityContract $credential): null | string
+    private function getCredThumbprint(?object $credential): null | string
     {
-        if (! $credential instanceof CredentialEntityContract) {
+        if (null === $credential) {
             return null;
         }
 


### PR DESCRIPTION
### Changes

The code currently performs full credential refreshes several times per request, which has a negative performance impact, especially when complex queries are involved. This change updates the SDK to refresh the credential once per request, and serve up a cached version of the credential for subsequent calls to getCredential within the same request thereafter.

Please see associated issue for more detailed information.

### References

https://github.com/auth0/laravel-auth0/issues/452

### Contributor Checklist

-   [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
-   [X] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
